### PR TITLE
Do not ask for AllowAlternatePorts in console

### DIFF
--- a/OpenSim/Framework/RegionInfo.cs
+++ b/OpenSim/Framework/RegionInfo.cs
@@ -672,7 +672,8 @@ namespace OpenSim.Framework
             }
             else
             {
-                m_allow_alternate_ports = Convert.ToBoolean(MainConsole.Instance.CmdPrompt("Allow alternate ports", "False"));
+                //Not Used. Leave it always False.
+                m_allow_alternate_ports = false;
 
                 config.Set("AllowAlternatePorts", m_allow_alternate_ports.ToString());
             }

--- a/OpenSim/Region/CoreModules/ServiceConnectorsOut/Grid/RemoteGridServiceConnector.cs
+++ b/OpenSim/Region/CoreModules/ServiceConnectorsOut/Grid/RemoteGridServiceConnector.cs
@@ -193,6 +193,7 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.Grid
         // The coordinates are world coords (meters), NOT region units.
         public GridRegion GetRegionByPosition(UUID scopeID, int x, int y)
         {
+            m_log.Debug("[REMOTE GRID CONNECTOR]: GetRegionByPosition");
             bool inCache = false;
             GridRegion rinfo = m_RegionInfoCache.Get(scopeID, Util.RegionWorldLocToHandle((uint)x, (uint)y), out inCache);
             if (inCache)

--- a/OpenSim/Region/CoreModules/ServiceConnectorsOut/UserAccounts/RemoteUserAccountServiceConnector.cs
+++ b/OpenSim/Region/CoreModules/ServiceConnectorsOut/UserAccounts/RemoteUserAccountServiceConnector.cs
@@ -145,13 +145,13 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.UserAccounts
 
             return account;
         }
-
+/*
         public override bool StoreUserAccount(UserAccount data)
         {
             // This remote connector refuses to serve this method
             return false;
         }
-
+*/
         #endregion
     }
 }

--- a/OpenSim/Server/Handlers/Authentication/AuthenticationServerPostHandler.cs
+++ b/OpenSim/Server/Handlers/Authentication/AuthenticationServerPostHandler.cs
@@ -140,8 +140,10 @@ namespace OpenSim.Server.Handlers.Authentication
                     return FailureResult();
     
                 case "setpassword":
-                    if (!m_AllowSetPassword)
+                    if (!m_AllowSetPassword) {
+                        m_log.ErrorFormat("[AUTHENTICATION SERVER POST HANDLER]: not allowed to set password cause of the AllowSetPassword setting.");
                         return FailureResult();
+                    }
 
                     if (!request.ContainsKey("PASSWORD"))
                         return FailureResult();
@@ -170,14 +172,20 @@ namespace OpenSim.Server.Handlers.Authentication
                     return FailureResult();
 
                 case "getauthinfo":
-                    if (m_AllowGetAuthInfo)
+                    if (m_AllowGetAuthInfo) {
                         return GetAuthInfo(principalID);
+                    } else {
+                        m_log.ErrorFormat("[AUTHENTICATION SERVER POST HANDLER]: not allowed to get Authentication Info cause of the AllowGetAuthInfo setting.");
+                    }
 
                     break;
 
                 case "setauthinfo":
-                    if (m_AllowSetAuthInfo)
+                    if (m_AllowSetAuthInfo) {
                         return SetAuthInfo(principalID, request);
+                    } else {
+                        m_log.ErrorFormat("[AUTHENTICATION SERVER POST HANDLER]: not allowed to set Authentication Info cause of the AllowSetAuthInfo setting.");
+                    }
 
                     break;
             }

--- a/OpenSim/Server/Handlers/UserAccounts/UserAccountServerPostHandler.cs
+++ b/OpenSim/Server/Handlers/UserAccounts/UserAccountServerPostHandler.cs
@@ -97,8 +97,10 @@ namespace OpenSim.Server.Handlers.UserAccounts
                     case "createuser":
                         if (m_AllowCreateUser)
                             return CreateUser(request);
-                        else
+                        else {
+                            m_log.DebugFormat("[USER SERVICE HANDLER]: not allowed to create a user, cause the AllowCreateUser settings in rubust.ini is set to false.");
                             break;
+                        }
                     case "getaccount":
                         return GetAccount(request);
                     case "getaccounts":
@@ -106,8 +108,10 @@ namespace OpenSim.Server.Handlers.UserAccounts
                     case "setaccount":
                         if (m_AllowSetAccount)
                             return StoreAccount(request);
-                        else
+                        else {
+                            m_log.DebugFormat("[USER SERVICE HANDLER]: not allowed to store a user, cause the AllowSetAccount settings in rubust.ini is set to false.");
                             break;
+                        }
                 }
 
                 m_log.DebugFormat("[USER SERVICE HANDLER]: unknown method request: {0}", method);
@@ -259,8 +263,8 @@ namespace OpenSim.Server.Handlers.UserAccounts
         {
             if (!
                 request.ContainsKey("FirstName")
-                    && request.ContainsKey("LastName")
-                    && request.ContainsKey("Password"))
+                    && request.ContainsKey("LastName"))
+                  //  && request.ContainsKey("Password"))
                 return FailureResult();
 
             Dictionary<string, object> result = new Dictionary<string, object>();
@@ -275,7 +279,8 @@ namespace OpenSim.Server.Handlers.UserAccounts
 
             string firstName = request["FirstName"].ToString();
             string lastName = request["LastName"].ToString();
-            string password = request["Password"].ToString();
+            string password = "temporary";  // set to a temporary password if created with a method wich does supply one but sets it later
+            if (request.ContainsKey("Password")) password = request["Password"].ToString();
 
             string email = "";
             if (request.ContainsKey("Email"))

--- a/OpenSim/Services/Connectors/Authentication/AuthenticationServicesConnector.cs
+++ b/OpenSim/Services/Connectors/Authentication/AuthenticationServicesConnector.cs
@@ -152,20 +152,41 @@ namespace OpenSim.Services.Connectors
 
         public bool SetPassword(UUID principalID, string passwd)
         {
-            // nope, we don't do this
-            return false;
+             m_log.Debug("[AUTH CONNECTOR]: SetPassword - set the password");
+            // nope, we don't do this setpassword
+            //return false;
+            Dictionary<string, object> sendData = new Dictionary<string, object>();
+            sendData["PRINCIPAL"] = principalID.ToString();  
+            sendData["PASSWORD"] = passwd;
+
+            sendData["METHOD"] = "setpassword";
+            
+            string reply = SynchronousRestFormsRequester.MakeRequest("POST",
+                    m_ServerURI + "/auth/plain",
+                    ServerUtils.BuildQueryString(sendData), m_Auth);
+
+            Dictionary<string, object> replyData = ServerUtils.ParseXmlResponse(
+                    reply);
+
+            if (replyData["Result"].ToString() != "Success")
+                return false;
+
+            return true;
         }
 
         public AuthInfo GetAuthInfo(UUID principalID)
         {
+            m_log.Error("[AUTH CONNECTOR]: GetAuthInfo - we do not do this ?");
             // not done from remote simulators
             return null;
         }
 
         public bool SetAuthInfo(AuthInfo info)
         {
+            m_log.Error("[AUTH CONNECTOR]: SetAuthInfo- we do not do this ?");
             // not done from remote simulators
             return false;
         }
+       
     }
 }

--- a/OpenSim/Services/Connectors/UserAccounts/UserAccountServicesConnector.cs
+++ b/OpenSim/Services/Connectors/UserAccounts/UserAccountServicesConnector.cs
@@ -273,10 +273,11 @@ namespace OpenSim.Services.Connectors
 
                     if (replyData.ContainsKey("result"))
                     {
-                        if (replyData["result"].ToString().ToLower() == "success")
-                            return true;
-                        else
+                        // the remote create user method to create a user gives back an object, but will give back failure if it fails
+                        if (replyData["result"].ToString().ToLower() == "failure")
                             return false;
+                        else
+                            return true;
                     }
                     else
                         m_log.DebugFormat("[ACCOUNTS CONNECTOR]: Set or Create UserAccount reply data does not contain result field");

--- a/OpenSim/Services/Interfaces/IUserAccountService.cs
+++ b/OpenSim/Services/Interfaces/IUserAccountService.cs
@@ -93,6 +93,8 @@ namespace OpenSim.Services.Interfaces
         public string UserTitle;
         public Boolean LocalToGrid = true;
 
+        public string METHOD;
+        
         public Dictionary<string, object> ServiceURLs;
 
         public int Created;
@@ -104,6 +106,8 @@ namespace OpenSim.Services.Interfaces
 
         public UserAccount(Dictionary<string, object> kvp)
         {
+            if (kvp.ContainsKey("METHOD"))
+                METHOD = kvp["METHOD"].ToString();
             if (kvp.ContainsKey("FirstName"))
                 FirstName = kvp["FirstName"].ToString();
             if (kvp.ContainsKey("LastName"))
@@ -156,7 +160,8 @@ namespace OpenSim.Services.Interfaces
             result["UserFlags"] = UserFlags.ToString();
             result["UserTitle"] = UserTitle;
             result["LocalToGrid"] = LocalToGrid.ToString();
-
+            result["METHOD"] = METHOD;
+            
             string str = string.Empty;
             foreach (KeyValuePair<string, object> kvp in ServiceURLs)
             {


### PR DESCRIPTION
Do not ask for the AllowAlternatePorts in the console when reading the
ini files.
info from wiki: Not Used. Leave it always False.
