### PR TITLE
Add some OSSL functions related to child prims inventory manipulations

### DIFF
--- a/OpenSim/Region/ScriptEngine/Shared/Api/Implementation/OSSL_Api.cs
+++ b/OpenSim/Region/ScriptEngine/Shared/Api/Implementation/OSSL_Api.cs
@@ -5583,7 +5583,7 @@ namespace OpenSim.Region.ScriptEngine.Shared.Api
             foreach (KeyValuePair<UUID, TaskInventoryItem> inv in m_host.TaskInventory)
             {
                 if (inv.Value.Type == type || type == -1)
-                    ret.Add(inv.Value.ItemID);
+                    ret.Add(inv.Value.ItemID.ToString());
             }
 
             m_host.TaskInventory.LockItemsForRead(false);

--- a/OpenSim/Region/ScriptEngine/Shared/Api/Interface/IOSSL_Api.cs
+++ b/OpenSim/Region/ScriptEngine/Shared/Api/Interface/IOSSL_Api.cs
@@ -561,8 +561,16 @@ namespace OpenSim.Region.ScriptEngine.Shared.Api.Interfaces
         LSL_Integer osApproxEquals(rotation ra, rotation rb, LSL_Float margin);
         LSL_Key osGetInventoryLastOwner(LSL_String itemNameOrId);
         LSL_Key osGetInventoryItemKey(LSL_String name);
+        LSL_Key osGetLinkInventoryKey(LSL_Integer linkNumber, LSL_String name);
         LSL_String osGetInventoryName(LSL_Key itemId);
+        LSL_String osGetLinkInventoryName(LSL_Integer linkNumber, LSL_Key itemId);
         LSL_String osGetInventoryDesc(LSL_String itemNameOrId);
+        LSL_String osGetLinkInventoryDesc(LSL_Integer linkNumber, LSL_String itemNameorid);
+        LSL_List osGetInventoryKeys(LSL_Integer type);
+        LSL_List osGetLinkInventoryKeys(LSL_Integer linkNumber, LSL_Integer type);
+        LSL_List osGetInventoryNames(LSL_Integer type);
+        LSL_List osGetLinkInventoryNames(LSL_Integer linkNumber, LSL_Integer type);
+        void osGiveLinkInventory(LSL_Integer linkNumber, LSL_Key destination, LSL_String inventory);
         LSL_Key osGetLastChangedEventKey();
         LSL_Float osGetPSTWallclock();
         LSL_Rotation osSlerp(LSL_Rotation a, LSL_Rotation b, LSL_Float amount);

--- a/OpenSim/Region/ScriptEngine/Shared/Api/Runtime/OSSL_Stub.cs
+++ b/OpenSim/Region/ScriptEngine/Shared/Api/Runtime/OSSL_Stub.cs
@@ -1461,15 +1461,58 @@ namespace OpenSim.Region.ScriptEngine.Shared.ScriptBase
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public LSL_Key osGetLinkInventoryKey(LSL_Integer linkNumber, LSL_String name)
+        {
+            return m_OSSL_Functions.osGetLinkInventoryKey(linkNumber, name);
+
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public LSL_List osGetInventoryKeys(LSL_Integer type)
+        {
+            return m_OSSL_Functions.osGetInventoryKeys(type);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public LSL_List osGetLinkInventoryKeys(LSL_Integer linkNumber, LSL_Integer type)
+        {
+           return m_OSSL_Functions.osGetLinkInventoryKeys(linkNumber, type);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public LSL_String osGetInventoryName(LSL_Key itemId)
         {
             return m_OSSL_Functions.osGetInventoryName(itemId);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public LSL_String osGetLinkInventoryName(LSL_Integer linkNumber, LSL_Key itemId)
+        {
+            return m_OSSL_Functions.osGetLinkInventoryName(linkNumber, itemId);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public LSL_List osGetLinkInventoryNames(LSL_Integer linkNumber, LSL_Integer type)
+        {
+           return m_OSSL_Functions.osGetLinkInventoryNames(linkNumber, type);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public LSL_String osGetInventoryDesc(LSL_String itemNameOrId)
         {
             return m_OSSL_Functions.osGetInventoryDesc(itemNameOrId);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public LSL_String osGetLinkInventoryDesc(LSL_Integer linkNumber, LSL_String itemNameOrId)
+        {
+            return m_OSSL_Functions.osGetLinkInventoryDesc(linkNumber, itemNameOrId);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void osGiveLinkInventory(LSL_Integer linkNumber, LSL_Key destination, LSL_String inventory)
+        {
+            m_OSSL_Functions.osGiveLinkInventory(linkNumber, destination, inventory);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/OpenSim/Region/ScriptEngine/Shared/Api/Runtime/OSSL_Stub.cs
+++ b/OpenSim/Region/ScriptEngine/Shared/Api/Runtime/OSSL_Stub.cs
@@ -1492,6 +1492,12 @@ namespace OpenSim.Region.ScriptEngine.Shared.ScriptBase
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public LSL_List osGetInventoryNames(LSL_Integer type)
+        {
+           return m_OSSL_Functions.osGetInventoryNames(type);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public LSL_List osGetLinkInventoryNames(LSL_Integer linkNumber, LSL_Integer type)
         {
            return m_OSSL_Functions.osGetLinkInventoryNames(linkNumber, type);

--- a/bin/ScriptSyntax.xml
+++ b/bin/ScriptSyntax.xml
@@ -7303,11 +7303,34 @@ fc2639fd-5d16-66bf-d8ab-2e4d754c816d
    <map><key>itemNameOrId</key><map><key>type</key><string>string</string></map></map>
   </array>
  </map>
+ <key>osGetLinkInventoryDesc</key>
+ <map>
+  <key>return</key><string>string</string>
+  <key>arguments</key><array>
+   <map><key>linkNumber</key><map><key>type</key><string>integer</string></map></map>
+   <map><key>itemNameOrId</key><map><key>type</key><string>string</string></map></map>
+  </array>
+ </map>
  <key>osGetInventoryItemKey</key>
  <map>
   <key>return</key><string>key</string>
   <key>arguments</key><array>
    <map><key>name</key><map><key>type</key><string>string</string></map></map>
+  </array>
+ </map>
+<key>osGetLinkInventoryKey</key>
+ <map>
+  <key>return</key><string>key</string>
+  <key>arguments</key><array>
+   <map><key>linkNumber</key><map><key>type</key><string>integer</string></map></map>
+   <map><key>name</key><map><key>type</key><string>string</string></map></map>
+  </array>
+ </map>
+ <key>osGetInventoryKeys</key>
+ <map>
+  <key>return</key><string>list</string>
+  <key>arguments</key><array>
+   <map><key>type</key><map><key>type</key><string>integer</string></map></map>
   </array>
  </map>
  <key>osGetInventoryLastOwner</key>
@@ -7322,6 +7345,38 @@ fc2639fd-5d16-66bf-d8ab-2e4d754c816d
   <key>return</key><string>string</string>
   <key>arguments</key><array>
    <map><key>itemId</key><map><key>type</key><string>key</string></map></map>
+  </array>
+ </map>
+ <key>osGetLinkInventoryName</key>
+ <map>
+  <key>return</key><string>string</string>
+  <key>arguments</key><array>
+   <map><key>linkNumber</key><map><key>type</key><string>integer</string></map></map>
+   <map><key>itemId</key><map><key>type</key><string>key</string></map></map>
+  </array>
+ </map>
+ <key>osGetLinkInventoryNames</key>
+ <map>
+  <key>return</key><string>list</string>
+  <key>arguments</key><array>
+   <map><key>linkNumber</key><map><key>type</key><string>integer</string></map></map>
+   <map><key>type</key><map><key>type</key><string>integer</string></map></map>
+  </array>
+ </map>
+ <key>osGetLinkInventoryKeys</key>
+ <map>
+  <key>return</key><string>list</string>
+  <key>arguments</key><array>
+   <map><key>linkNumber</key><map><key>type</key><string>integer</string></map></map>
+   <map><key>type</key><map><key>type</key><string>integer</string></map></map>
+  </array>
+ </map>
+ <key>osGiveLinkInventory</key>
+ <map>
+  <key>arguments</key><array>
+   <map><key>linkNumber</key><map><key>type</key><string>integer</string></map></map>
+   <map><key>destination</key><map><key>type</key><string>key</string></map></map>
+   <map><key>inventory</key><map><key>type</key><string>string</string></map></map>
   </array>
  </map>
  <key>osGetLastChangedEventKey</key>


### PR DESCRIPTION
Add functions:

+ osGiveLinkInventory(integer linkNumber, key destination, string inventory) 
Give an item located in a child prim inventory.

+ osGetInventoryNames(integer type) 
Return a list of items names by type (or INVENTORY_ALL) located in the prim inventory.

+ osGetLinkInventoryNames(integer linkNumber, integer type) 
Return a list of items names by type (or INVENTORY_ALL) located in a child prim inventory.

+ osGetInventoryKeys(integer type) 
Return a list of the items UUIDs by type (or INVENTORY_ALL) located in the prim inventory.

+ osGetLinkInventoryKeys(integer linkNumber, integer type) 
Return a list of the items UUIDs by type (or INVENTORY_ALL) located in a child prim inventory.

+ osGetLinkInventoryKey(integer linkNumber, string name) 
Return the UUID of the specified item name located in a child prim inventory.

+ osGetLinkInventoryDesc(integer linkNumber, string itemNameorid) 
Return the description of an item located in a child prim inventory.

+ osGetLinkInventoryName(integer linkNumber, key itemId) 
Return the name of an item located in a child prim inventory.

Note: the LinkInventory functions don't have access to the root prim contents. This may change if requested by the community...

Web Rain :)