### PR TITLE
Add 2 OSSL functions to the LinkInventory collection

### DIFF
--- a/OpenSim/Region/ScriptEngine/Shared/Api/Interface/IOSSL_Api.cs
+++ b/OpenSim/Region/ScriptEngine/Shared/Api/Interface/IOSSL_Api.cs
@@ -570,7 +570,9 @@ namespace OpenSim.Region.ScriptEngine.Shared.Api.Interfaces
         LSL_List osGetLinkInventoryKeys(LSL_Integer linkNumber, LSL_Integer type);
         LSL_List osGetInventoryNames(LSL_Integer type);
         LSL_List osGetLinkInventoryNames(LSL_Integer linkNumber, LSL_Integer type);
+        void osRemoveLinkInventory(LSL_Integer linkNumber, LSL_String name);
         void osGiveLinkInventory(LSL_Integer linkNumber, LSL_Key destination, LSL_String inventory);
+        void osGiveLinkInventoryList(LSL_Integer linkNumber, LSL_Key destination, LSL_String category, LSL_List inventory);
         LSL_Key osGetLastChangedEventKey();
         LSL_Float osGetPSTWallclock();
         LSL_Rotation osSlerp(LSL_Rotation a, LSL_Rotation b, LSL_Float amount);

--- a/OpenSim/Region/ScriptEngine/Shared/Api/Runtime/OSSL_Stub.cs
+++ b/OpenSim/Region/ScriptEngine/Shared/Api/Runtime/OSSL_Stub.cs
@@ -1516,9 +1516,20 @@ namespace OpenSim.Region.ScriptEngine.Shared.ScriptBase
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void osRemoveLinkInventory(LSL_Integer linkNumber, LSL_String name)
+        {
+            m_OSSL_Functions.osRemoveLinkInventory(linkNumber, name);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void osGiveLinkInventory(LSL_Integer linkNumber, LSL_Key destination, LSL_String inventory)
         {
             m_OSSL_Functions.osGiveLinkInventory(linkNumber, destination, inventory);
+        }
+
+        public void osGiveLinkInventoryList(LSL_Integer linkNumber, LSL_Key destination, LSL_String category, LSL_List inventory)
+        {
+            m_OSSL_Functions.osGiveLinkInventoryList(linkNumber, destination, category, inventory);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/bin/ScriptSyntax.xml
+++ b/bin/ScriptSyntax.xml
@@ -7378,11 +7378,27 @@ fc2639fd-5d16-66bf-d8ab-2e4d754c816d
    <map><key>type</key><map><key>type</key><string>integer</string></map></map>
   </array>
  </map>
+ <key>osRemoveLinkInventory</key>
+ <map>
+  <key>arguments</key><array>
+   <map><key>linkNumber</key><map><key>type</key><string>integer</string></map></map>
+   <map><key>name</key><map><key>type</key><string>integer</string></map></map>
+  </array>
+ </map>
  <key>osGiveLinkInventory</key>
  <map>
   <key>arguments</key><array>
    <map><key>linkNumber</key><map><key>type</key><string>integer</string></map></map>
    <map><key>destination</key><map><key>type</key><string>key</string></map></map>
+   <map><key>inventory</key><map><key>type</key><string>string</string></map></map>
+  </array>
+ </map>
+ <key>osGiveLinkInventoryList</key>
+ <map>
+  <key>arguments</key><array>
+   <map><key>linkNumber</key><map><key>type</key><string>integer</string></map></map>
+   <map><key>destination</key><map><key>type</key><string>key</string></map></map>
+   <map><key>category</key><map><key>type</key><string>string</string></map></map>
    <map><key>inventory</key><map><key>type</key><string>string</string></map></map>
   </array>
  </map>


### PR DESCRIPTION
Add Functions:
+ osGiveLinkInventoryList(integer linkNumber, key destination, string category, list inventory) 
Give a group of items located in a child prim inventory

+ osRemoveLinkInventory(integer linkNumber, string name) 
Remove an item from a child prim inventory

LSL Script example:
<pre><code>
default
{
    touch_start(integer a){

        integer linkNumber = llDetectedLinkNumber(0);
        list linkInventoryNames = osGetLinkInventoryNames(linkNumber, INVENTORY_ALL);
        osGiveLinkInventoryList(linkNumber, llDetectedKey(0), llGetLinkName(linkNumber), linkInventoryNames);

        for(integer i = 0; i < llGetListLength(linkInventoryNames); i++){
            osRemoveLinkInventory(linkNumber, llList2String(linkInventoryNames, i));
        }
    }
}
</code></pre>

Web Rain :)