### PR TITLE
Add llGetNotecardLineSync

### DIFF
--- a/OpenSim/Region/ScriptEngine/Shared/Api/Implementation/LSL_Api.cs
+++ b/OpenSim/Region/ScriptEngine/Shared/Api/Implementation/LSL_Api.cs
@@ -14985,6 +14985,32 @@ namespace OpenSim.Region.ScriptEngine.Shared.Api
             return tid.ToString();
         }
 
+        public LSL_String llGetNotecardLineSync(string name, int line)
+        {
+            if (!UUID.TryParse(name, out UUID assetID))
+            {
+                TaskInventoryItem item = m_host.Inventory.GetInventoryItem(name);
+                
+                if (item != null && item.Type == 7)
+                    assetID = item.AssetID;
+                else
+                {
+                    Error("llGetNotecardLineSync", "Can't find notecard '" + name + "'");
+
+                    return ScriptBaseClass.NAK;
+                }
+            }
+
+            if (NotecardCache.IsCached(assetID))
+            {
+                return NotecardCache.GetLine(assetID, line, m_notecardLineReadCharsMax);
+            }
+            else
+            {
+                return ScriptBaseClass.NAK;
+            }
+        }
+
         public LSL_Key llGetNotecardLine(string name, int line)
         {
             if (!UUID.TryParse(name, out UUID assetID))

--- a/OpenSim/Region/ScriptEngine/Shared/Api/Interface/ILSL_Api.cs
+++ b/OpenSim/Region/ScriptEngine/Shared/Api/Interface/ILSL_Api.cs
@@ -176,6 +176,7 @@ namespace OpenSim.Region.ScriptEngine.Shared.Api.Interfaces
               void llGetNextEmail(string address, string subject);
            LSL_Key llGetNotecardLine(string name, int line);
            LSL_Key llGetNumberOfNotecardLines(string name);
+        LSL_String llGetNotecardLineSync(string name, int line);
        LSL_Integer llGetNumberOfPrims();
        LSL_Integer llGetNumberOfSides();
         LSL_String llGetObjectDesc();

--- a/OpenSim/Region/ScriptEngine/Shared/Api/Runtime/LSL_Constants.cs
+++ b/OpenSim/Region/ScriptEngine/Shared/Api/Runtime/LSL_Constants.cs
@@ -609,6 +609,7 @@ namespace OpenSim.Region.ScriptEngine.Shared.ScriptBase
 
         public const string NULL_KEY = "00000000-0000-0000-0000-000000000000";
         public const string EOF = "\n\n\n";
+        public const string NAK = "\n\u0015\n";
         public const double PI = 3.14159274f;
         public const double TWO_PI = 6.28318548f;
         public const double PI_BY_TWO = 1.57079637f;

--- a/OpenSim/Region/ScriptEngine/Shared/Api/Runtime/LSL_Stub.cs
+++ b/OpenSim/Region/ScriptEngine/Shared/Api/Runtime/LSL_Stub.cs
@@ -759,6 +759,12 @@ namespace OpenSim.Region.ScriptEngine.Shared.ScriptBase
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public LSL_String llGetNotecardLineSync(string name, int line)
+        {
+            return m_LSL_Functions.llGetNotecardLineSync(name, line);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public LSL_Integer llGetNumberOfPrims()
         {
             return m_LSL_Functions.llGetNumberOfPrims();


### PR DESCRIPTION
Implements the https://wiki.secondlife.com/wiki/LlGetNotecardLineSync function

Not entirely sure how to handle threat level for it tho.
The os equivalent ([osGetNotecardLine](http://opensimulator.org/wiki/OsGetNotecardLine)) does an CheckThreatLevel, and I suppose there is a point with that.

Right now I have implemented it so that if the notecard is accessed by name, it can find a cached notecard in the prim inventory without the threat level check, but if you try to do it by UUID, it uses the osGetNotecardLine's ThreatLevel.