### PR TITLE
Fix SmoothArea to be uniform again

### DIFF
--- a/OpenSim/Region/CoreModules/World/Terrain/FloodBrushes/SmoothArea.cs
+++ b/OpenSim/Region/CoreModules/World/Terrain/FloodBrushes/SmoothArea.cs
@@ -64,7 +64,7 @@ namespace OpenSim.Region.CoreModules.World.Terrain.FloodBrushes
                     {
                         if (n >= 0 && n < map.Width)
                         {
-                            for (int l = y - sy; l < y + sy; ++l)
+                            for (int l = y - sy; l <= y + sy; ++l)
                             {
                                 if (l >= 0 && l < map.Height)
                                 {


### PR DESCRIPTION
Explains why it was only visible in northern direction, that's where it would stop short. Tested and restores uniform behavior of smooth.