### PR TITLE
PBR Terrain Maptile

### DIFF
--- a/OpenSim/Region/CoreModules/World/Warp3DMap/Warp3DImageModule.cs
+++ b/OpenSim/Region/CoreModules/World/Warp3DMap/Warp3DImageModule.cs
@@ -395,6 +395,16 @@ namespace OpenSim.Region.CoreModules.World.Warp3DMap
                 regionInfo.TerrainTexture3,
                 regionInfo.TerrainTexture4,
             };
+            if (regionInfo.TerrainPBR1 != null)
+            {
+                textureIDs = new UUID[4]
+                {
+                    regionInfo.TerrainPBR1,
+                    regionInfo.TerrainPBR2,
+                    regionInfo.TerrainPBR3,
+                    regionInfo.TerrainPBR4,
+                };
+            }
 
             float[] startHeights = new float[4]
             {


### PR DESCRIPTION
This is so Warp3D can generate PBR terrain textures on the map if PBR is available. Feel free to update the code if needs be. Tested and works perfectly on my grid.