### PR TITLE
Fix response for vivox server type under webrtc

### DIFF
--- a/OpenSim/Addons/os-webrtc-janus/WebRtcVoiceRegionModule/WebRtcVoiceRegionModule.cs
+++ b/OpenSim/Addons/os-webrtc-janus/WebRtcVoiceRegionModule/WebRtcVoiceRegionModule.cs
@@ -417,7 +417,7 @@ namespace osWebRtcVoice
                         m_log.Warn($"{LogHeader}[ProvisionVoice]: Request detail: {map}");
 
                     response.RawBuffer = llsdUndefAnswerBytes;
-                    response.StatusCode = (int)HttpStatusCode.OK;
+                    response.StatusCode = 0;
                     return;
                 }
             }


### PR DESCRIPTION
Not setting a status code or anything that isn't an invalid status code makes the viewer think that vivox is provisioned and can be used. Not responding at all doesn't seem to work either so instead it just returns 0 as invalid status code. The viewer still attempts retries for vivox, but eventually gives up. Meanwhile webrtc requests go through just fine. It's not a great solution given the retries, but looking the viewer code there doesn't appear to be a way to properly trigger its bailout condition with the way handlers work on the server end.