### PR TITLE
Update LandManagementModule.cs

### DIFF
--- a/OpenSim/Region/CoreModules/World/Land/LandManagementModule.cs
+++ b/OpenSim/Region/CoreModules/World/Land/LandManagementModule.cs
@@ -2117,7 +2117,33 @@ namespace OpenSim.Region.CoreModules.World.Land
                     {
                         // if you do a "About Landmark" on a landmark a second time, the viewer sends the
                         // region_handle it got earlier via RegionHandleRequest
-                        ulong regionHandle = tmp.AsULong();
+                        
+                        //ulong regionHandle = tmp.AsULong();
+
+                        byte[] handleBytes = tmp.AsBinary();
+
+                        if (handleBytes == null || handleBytes.Length != 8)
+                        {
+                            m_log.WarnFormat(
+                                "[LAND MANAGEMENT MODULE]: Bad RemoteParcelRequest region_handle length={0}",
+                                handleBytes == null ? -1 : handleBytes.Length
+                            );
+
+                            response.StatusCode = (int)HttpStatusCode.BadRequest;
+                            return;
+                        }
+
+                        ulong regionHandle =
+                            ((ulong)handleBytes[0] << 56) |
+                            ((ulong)handleBytes[1] << 48) |
+                            ((ulong)handleBytes[2] << 40) |
+                            ((ulong)handleBytes[3] << 32) |
+                            ((ulong)handleBytes[4] << 24) |
+                            ((ulong)handleBytes[5] << 16) |
+                            ((ulong)handleBytes[6] << 8) |
+                            handleBytes[7];
+
+
                         if(regionHandle == myHandle)
                         {
                             ILandObject l = GetLandObjectClippedXY(x, y);


### PR DESCRIPTION
please check this out... maybe issue :) there appears to be a regression happening in recent libomp commit, i noticed my CPUs on all updated region servers cooking high load and using dotnet-stack tool i think possibly caused by BytesToUInt64Big() in the new OpenMetaverseTypes.dll .. the OSDBinary.AsULong() in RemoteParcelRequest 

this updated file avoids use of BytesToUInt64Big() in tmp.AsULong().  please review 

side note:
also should probably rate limit and log requests, an attacker can connect through 9000 to region server making multiple http requests for RemoteParcelRequest causing a potential denial of service.