### PR TITLE
Implement traveling friends notifications and status updates

### DIFF
--- a/OpenSim/Data/MySQL/Resources/HGTravelStore.migrations
+++ b/OpenSim/Data/MySQL/Resources/HGTravelStore.migrations
@@ -22,3 +22,11 @@ ALTER TABLE `hg_traveling_data` MODIFY `TMStamp` timestamp NOT NULL default CURR
 
 COMMIT;
 
+:VERSION 3         # --------------------------
+
+BEGIN;
+
+ALTER TABLE `hg_traveling_data` ADD COLUMN `RegionURI` VARCHAR(255) NOT NULL DEFAULT '';
+
+COMMIT;
+

--- a/OpenSim/Data/PGSQL/Resources/HGTravelStore.migrations
+++ b/OpenSim/Data/PGSQL/Resources/HGTravelStore.migrations
@@ -15,3 +15,11 @@ CREATE TABLE hg_traveling_data (
 
 COMMIT;
 
+:VERSION 2         # --------------------------
+
+BEGIN;
+
+ALTER TABLE hg_traveling_data ADD COLUMN "RegionURI" VARCHAR(255) NOT NULL DEFAULT '';
+
+COMMIT;
+

--- a/OpenSim/Data/SQLite/Resources/HGTravelStore.migrations
+++ b/OpenSim/Data/SQLite/Resources/HGTravelStore.migrations
@@ -16,3 +16,11 @@ CREATE TABLE hg_traveling_data(
 
 COMMIT;
 
+:VERSION 3         # --------------------------
+
+BEGIN;
+
+ALTER TABLE hg_traveling_data ADD COLUMN RegionURI VARCHAR(255) NOT NULL DEFAULT "";
+
+COMMIT;
+

--- a/OpenSim/Region/CoreModules/Avatar/Friends/FriendsModule.cs
+++ b/OpenSim/Region/CoreModules/Avatar/Friends/FriendsModule.cs
@@ -291,7 +291,8 @@ namespace OpenSim.Region.CoreModules.Avatar.Friends
             }
         }
 
-        public virtual void CacheFriendOnline(UUID userID, UUID friendID, bool online)
+        /// <returns>true if the cached online state actually changed</returns>
+        public virtual bool CacheFriendOnline(UUID userID, UUID friendID, bool online)
         {
             if (!m_OnlineFriendsCache.TryGetValue(userID, out HashSet<UUID> friends))
             {
@@ -299,9 +300,9 @@ namespace OpenSim.Region.CoreModules.Avatar.Friends
                 m_OnlineFriendsCache[userID] = friends;
             }
             if (online)
-                friends.Add(friendID);
+                return friends.Add(friendID);
             else
-                friends.Remove(friendID);
+                return friends.Remove(friendID);
         }
         public virtual List<UUID> GetCachedFriendsOnline(UUID userID)
         {
@@ -446,7 +447,7 @@ namespace OpenSim.Region.CoreModules.Avatar.Friends
             }
 
             // Send the friends online
-            List<UUID> online = GetOnlineFriends(client.AgentId);
+            List<UUID> online = GetOnlineFriends(client.AgentId, client.SessionId);
 
             if (online.Count > 0)
                 client.SendAgentOnline(online.ToArray());
@@ -504,7 +505,7 @@ namespace OpenSim.Region.CoreModules.Avatar.Friends
             return true;
         }
 
-        List<UUID> GetOnlineFriends(UUID userID)
+        List<UUID> GetOnlineFriends(UUID userID, UUID sessionID)
         {
             List<UUID> online = new();
             FriendInfo[] friends = GetFriendsFromCache(userID);
@@ -519,7 +520,7 @@ namespace OpenSim.Region.CoreModules.Avatar.Friends
             }
 
             if (friendList.Count > 0)
-                GetOnlineFriends(userID, friendList, online);
+                GetOnlineFriends(userID, sessionID, friendList, online);
 
             //m_log.DebugFormat(
             //    "[FRIENDS MODULE]: User {0} has {1} friends online", userID, online.Count);
@@ -527,7 +528,11 @@ namespace OpenSim.Region.CoreModules.Avatar.Friends
             return online;
         }
 
-        protected virtual void GetOnlineFriends(UUID userID, List<string> friendList, List<UUID> online)
+        /// <param name="sessionID">userID's own live session on this grid (the caller's,
+        /// i.e. client.SessionId at login) — unused here, but threaded through so the
+        /// HG override can present it to the grid's own HGFriendsService as a capability
+        /// proving the query genuinely originates from userID's connected session.</param>
+        protected virtual void GetOnlineFriends(UUID userID, UUID sessionID, List<string> friendList, List<UUID> online)
         {
             //m_log.DebugFormat(
             //    "[FRIENDS MODULE]: Looking for online presence of {0} users for {1}", friendList.Count, userID);
@@ -590,6 +595,16 @@ namespace OpenSim.Region.CoreModules.Avatar.Friends
 
             if(friendList.Count > 0)
             {
+                // resolved here, before the async hop, so it reflects the live client
+                // at the moment of the status change; threaded through to the HG
+                // override as a capability proving the call genuinely originates from
+                // agentID's own connected session (see StatusNotify's sessionID param)
+                UUID sessionID = LocateClientObject(agentID)?.SessionId ?? UUID.Zero;
+                if (sessionID.IsZero())
+                    // downstream this means the HG traveling-friends delivery will be
+                    // rejected server-side; make that visible instead of a silent drop
+                    m_log.DebugFormat("[FRIENDS MODULE]: StatusChange({0}) for {1}: client object no longer " +
+                        "resolvable, notifying without a session capability", online ? "online" : "offline", agentID);
                 Util.FireAndForget(
                     delegate
                     {
@@ -598,13 +613,21 @@ namespace OpenSim.Region.CoreModules.Avatar.Friends
                         //    friendList.Count, agentID, online);
 
                         // Notify about this user status
-                        StatusNotify(friendList, agentID, online);
+                        StatusNotify(friendList, agentID, sessionID, online);
                     }, null, "FriendsModule.StatusChange"
                 );
             }
         }
 
-        protected virtual void StatusNotify(List<FriendInfo> friendList, UUID userID, bool online)
+        /// <param name="sessionID">userID's own live session on this grid — unused here,
+        /// but threaded through so the HG override can present it to the grid's own
+        /// HGFriendsService as a capability proving the notification genuinely
+        /// originates from userID's connected session.</param>
+        /// <returns>The friend IDs that could not be delivered to because they have no
+        /// usable presence session on this grid — they are either offline or traveling
+        /// on a foreign grid (the home presence row is deleted while abroad); the two
+        /// are indistinguishable here. HGFriendsModule follows up on these.</returns>
+        protected virtual List<string> StatusNotify(List<FriendInfo> friendList, UUID userID, UUID sessionID, bool online)
         {
             //m_log.DebugFormat("[FRIENDS]: Entering StatusNotify for {0}", userID);
             List<string> remoteFriendStringIds = new(friendList.Count);
@@ -623,29 +646,34 @@ namespace OpenSim.Region.CoreModules.Avatar.Friends
             }
 
             if (remoteFriendStringIds.Count == 0)
-                return;
+                return remoteFriendStringIds;
+
+            HashSet<string> undelivered = new(remoteFriendStringIds);
 
             // We do this regrouping so that we can efficiently send a single request rather than one for each
             // friend in what may be a very large friends list.
             PresenceInfo[] friendSessions = PresenceService.GetAgents(remoteFriendStringIds.ToArray());
-            if(friendSessions is null)
-                return;
-
-            foreach (PresenceInfo friendSession in friendSessions)
+            if (friendSessions is not null)
             {
-                // let's guard against sessions-gone-bad
-                if (friendSession is not null && friendSession.RegionID.IsNotZero())
+                foreach (PresenceInfo friendSession in friendSessions)
                 {
-                    //m_log.DebugFormat("[FRIENDS]: Get region {0}", friendSession.RegionID);
-                    GridRegion region = GridService.GetRegionByUUID(m_Scenes[0].RegionInfo.ScopeID, friendSession.RegionID);
-                    if (region is not null)
+                    // let's guard against sessions-gone-bad
+                    if (friendSession is not null && friendSession.RegionID.IsNotZero())
                     {
-                        m_FriendsSimConnector.StatusNotify(region, userID, friendSession.UserID, online);
+                        //m_log.DebugFormat("[FRIENDS]: Get region {0}", friendSession.RegionID);
+                        GridRegion region = GridService.GetRegionByUUID(m_Scenes[0].RegionInfo.ScopeID, friendSession.RegionID);
+                        if (region is not null)
+                        {
+                            m_FriendsSimConnector.StatusNotify(region, userID, friendSession.UserID, online);
+                            undelivered.Remove(friendSession.UserID);
+                        }
                     }
+                    //else
+                    //    m_log.DebugFormat("[FRIENDS]: friend session is null or the region is UUID.Zero");
                 }
-                //else
-                //    m_log.DebugFormat("[FRIENDS]: friend session is null or the region is UUID.Zero");
             }
+
+            return new List<string>(undelivered);
         }
 
         protected virtual void OnInstantMessage(IClientAPI client, GridInstantMessage im)
@@ -738,6 +766,10 @@ namespace OpenSim.Region.CoreModules.Avatar.Friends
             // Try Local
             if (LocalFriendshipApproved(client.AgentId, client.Name, friendID))
             {
+                // keep the online cache in sync with what the viewer is told,
+                // so the state-change gate in LocalStatusNotification doesn't
+                // later swallow this friend's status changes
+                CacheFriendOnline(client.AgentId, friendID, true);
                 client.SendAgentOnline(new UUID[] { friendID });
                 return;
             }
@@ -751,6 +783,7 @@ namespace OpenSim.Region.CoreModules.Avatar.Friends
                 {
                     GridRegion region = GridService.GetRegionByUUID(m_Scenes[0].RegionInfo.ScopeID, friendSession.RegionID);
                     m_FriendsSimConnector.FriendshipApproved(region, client.AgentId, client.Name, friendID);
+                    CacheFriendOnline(client.AgentId, friendID, true);
                     client.SendAgentOnline(new UUID[] { friendID });
                 }
             }
@@ -1018,10 +1051,17 @@ namespace OpenSim.Region.CoreModules.Avatar.Friends
                 bool onlineBitChanged = (changedRights & (int)FriendRights.CanSeeOnline) != 0;
                 if (onlineBitChanged)
                 {
+                    // keep the online cache in sync with what the viewer is told
                     if ((newRights & (int)FriendRights.CanSeeOnline) == 1)
+                    {
+                        CacheFriendOnline(friendID, userID, true);
                         friendClient.SendAgentOnline(new UUID[] { userID });
+                    }
                     else
+                    {
+                        CacheFriendOnline(friendID, userID, false);
                         friendClient.SendAgentOffline(new UUID[] { userID });
+                    }
                 }
 
                 if(changedRights != 0)
@@ -1043,10 +1083,19 @@ namespace OpenSim.Region.CoreModules.Avatar.Friends
             IClientAPI friendClient = LocateClientObject(friendID);
             if (friendClient is not null)
             {
-                CacheFriendOnline(friendID, userID, online);
-                // the friend in this sim as root agent
+                bool changed = CacheFriendOnline(friendID, userID, online);
+                // the friend in this sim as root agent.
+                // Suppress only repeated "online" notifications (e.g. an HG
+                // traveler returning home triggers a fresh "online" that would
+                // pop a redundant toast). "offline" is always delivered: the
+                // cache may lack entries the viewer was told about directly
+                // (mid-session friendships, rights changes), and a suppressed
+                // offline would leave a ghost online friend until relog.
                 if (online)
-                    friendClient.SendAgentOnline(new UUID[] { userID });
+                {
+                    if (changed)
+                        friendClient.SendAgentOnline(new UUID[] { userID });
+                }
                 else
                     friendClient.SendAgentOffline(new UUID[] { userID });
                 // we're done

--- a/OpenSim/Region/CoreModules/Avatar/Friends/HGFriendsModule.cs
+++ b/OpenSim/Region/CoreModules/Avatar/Friends/HGFriendsModule.cs
@@ -52,6 +52,7 @@ namespace OpenSim.Region.CoreModules.Avatar.Friends
         private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
 
         private int m_levelHGFriends = 0;
+        private string m_ThisGridURL = string.Empty;
 
         IUserManagement m_uMan;
         public IUserManagement UserManagementModule
@@ -92,6 +93,11 @@ namespace OpenSim.Region.CoreModules.Avatar.Friends
         protected override void InitModule(IConfigSource config)
         {
             base.InitModule(config);
+
+            // our own grid's HGFriendsService lives at the HomeURI base; used to
+            // deliver status changes to local friends traveling on foreign grids
+            m_ThisGridURL = Util.GetConfigVarFromSections<string>(config, "HomeURI",
+                new string[] { "Startup", "Hypergrid", "HGFriendsModule" }, string.Empty);
 
             // Additionally to the base method
             IConfig friendsConfig = config.Configs["HGFriendsModule"];
@@ -220,7 +226,7 @@ namespace OpenSim.Region.CoreModules.Avatar.Friends
             return false;
         }
 
-        protected override void GetOnlineFriends(UUID userID, List<string> friendList, /*collector*/ List<UUID> online)
+        protected override void GetOnlineFriends(UUID userID, UUID sessionID, List<string> friendList, /*collector*/ List<UUID> online)
         {
             //m_log.DebugFormat("[HGFRIENDS MODULE]: Entering GetOnlineFriends for {0}", userID);
 
@@ -238,8 +244,6 @@ namespace OpenSim.Region.CoreModules.Avatar.Friends
             // FIXME: also query the presence status of friends in other grids (like in HGStatusNotifier.Notify())
 
             PresenceInfo[] presence = PresenceService.GetAgents(fList.ToArray());
-            if (presence.Length == 0)
-                return;
 
             if (!m_OnlineFriendsCache.TryGetValue(userID, out HashSet<UUID> friends))
             {
@@ -247,19 +251,40 @@ namespace OpenSim.Region.CoreModules.Avatar.Friends
                 m_OnlineFriendsCache[userID] = friends;
             }
 
+            HashSet<string> foundAtHome = new();
             foreach (PresenceInfo pi in presence)
             {
                 if (UUID.TryParse(pi.UserID, out UUID presenceID))
                 {
                     online.Add(presenceID);
                     friends.Add(presenceID);
+                    foundAtHome.Add(pi.UserID);
+                }
+            }
+
+            // Local friends with no home presence may be traveling on a foreign grid
+            // (their home presence row is deleted while abroad). Ask our own grid's
+            // HGFriendsService, which filters by travel record, so they show as
+            // online in the login snapshot too.
+            if (foundAtHome.Count < fList.Count && !string.IsNullOrEmpty(m_ThisGridURL))
+            {
+                List<string> candidates = new(fList.Count - foundAtHome.Count);
+                foreach (string s in fList)
+                    if (!foundAtHome.Contains(s))
+                        candidates.Add(s);
+
+                HGFriendsServicesConnector conn = new(m_ThisGridURL);
+                foreach (UUID id in conn.GetTravelingFriends(userID, sessionID, candidates))
+                {
+                    online.Add(id);
+                    friends.Add(id);
                 }
             }
 
             //m_log.DebugFormat("[HGFRIENDS MODULE]: Exiting GetOnlineFriends for {0}", userID);
         }
 
-        protected override void StatusNotify(List<FriendInfo> friendList, UUID userID, bool online)
+        protected override List<string> StatusNotify(List<FriendInfo> friendList, UUID userID, UUID sessionID, bool online)
         {
             //m_log.DebugFormat("[HGFRIENDS MODULE]: Entering StatusNotify for {0}", userID);
 
@@ -296,13 +321,29 @@ namespace OpenSim.Region.CoreModules.Avatar.Friends
 
             // For the local friends, just call the base method
             // Let's do this first of all
+            List<string> undelivered = new();
             if (locallst.Count > 0)
-                base.StatusNotify(locallst, userID, online);
+                undelivered = base.StatusNotify(locallst, userID, sessionID, online);
+
+            // Local friends with no presence here may be traveling on a foreign grid
+            // (their home presence row is deleted while abroad, so they look exactly
+            // like offline friends). Hand them to our own grid's HGFriendsService,
+            // which filters by travel record and delivers via the visited grid.
+            if (undelivered.Count > 0 && !string.IsNullOrEmpty(m_ThisGridURL))
+            {
+                List<string> candidates = undelivered;
+                Util.FireAndForget(o =>
+                {
+                    HGFriendsServicesConnector conn = new(m_ThisGridURL);
+                    conn.StatusNotifyTraveling(candidates, userID, sessionID, online);
+                }, null, "HGFriendsModule.StatusNotifyTraveling");
+            }
 
             if(friendsPerDomain.Count > 0)
                 m_StatusNotifier.Notify(userID, friendsPerDomain, online);
 
             //m_log.DebugFormat("[HGFRIENDS MODULE]: Exiting StatusNotify for {0}", userID);
+            return undelivered;
         }
 
         protected override bool GetAgentInfo(UUID scopeID, string fid, out UUID agentID, out string first, out string last)

--- a/OpenSim/Region/CoreModules/ServiceConnectorsOut/Presence/BasePresenceServiceConnector.cs
+++ b/OpenSim/Region/CoreModules/ServiceConnectorsOut/Presence/BasePresenceServiceConnector.cs
@@ -132,6 +132,11 @@ namespace OpenSim.Region.CoreModules.ServiceConnectorsOut.Presence
             return m_PresenceService.GetAgents(userIDs);
         }
 
+        public bool WasRecentlyLoggedOut(UUID sessionID, UUID userID)
+        {
+            return m_PresenceService.WasRecentlyLoggedOut(sessionID, userID);
+        }
+
         #endregion
     }
 }

--- a/OpenSim/Region/Framework/Interfaces/IFriendsModule.cs
+++ b/OpenSim/Region/Framework/Interfaces/IFriendsModule.cs
@@ -98,7 +98,8 @@ namespace OpenSim.Region.Framework.Interfaces
         bool SendFriendsOnlineIfNeeded(IClientAPI client);
         bool IsFriendOnline(UUID userID, UUID friendID);
         void CacheFriendsOnline(UUID userID, List<UUID> friendsOnline, bool online);
-        void CacheFriendOnline(UUID userID, UUID friendOnline, bool online);
+        /// <returns>true if the cached online state actually changed</returns>
+        bool CacheFriendOnline(UUID userID, UUID friendOnline, bool online);
         List<UUID> GetCachedFriendsOnline(UUID userID);
         bool IsFriend(UUID userID, UUID friendID);
     }

--- a/OpenSim/Server/Handlers/Hypergrid/GatekeeperServerConnector.cs
+++ b/OpenSim/Server/Handlers/Hypergrid/GatekeeperServerConnector.cs
@@ -72,6 +72,7 @@ namespace OpenSim.Server.Handlers.Hypergrid
             HypergridHandlers hghandlers = new HypergridHandlers(m_GatekeeperService);
             server.AddXmlRPCHandler("link_region", hghandlers.LinkRegionRequest, false);
             server.AddXmlRPCHandler("get_region", hghandlers.GetRegion, false);
+            server.AddXmlRPCHandler("status_notify", hghandlers.StatusNotify, false);
 
             server.AddSimpleStreamHandler(new GatekeeperAgentHandler(m_GatekeeperService, m_Proxy),true);
         }

--- a/OpenSim/Server/Handlers/Hypergrid/HGFriendsServerPostHandler.cs
+++ b/OpenSim/Server/Handlers/Hypergrid/HGFriendsServerPostHandler.cs
@@ -109,6 +109,12 @@ namespace OpenSim.Server.Handlers.Hypergrid
 
                     case "statusnotification":
                         return StatusNotification(request);
+
+                    case "statusnotify_traveling":
+                        return StatusNotifyTraveling(request);
+
+                    case "gettravelingfriends":
+                        return GetTravelingFriends(request);
                     /*
                     case "friendship_approved":
                         return FriendshipApproved(request);
@@ -214,6 +220,104 @@ namespace OpenSim.Server.Handlers.Hypergrid
             bool success = m_TheService.ValidateFriendshipOffered(friend.PrincipalID, friendID);
 
             return BoolResult(success);
+        }
+
+        byte[] GetTravelingFriends(Dictionary<string, object> request)
+        {
+            object tmpObj;
+            UUID principalID = UUID.Zero;
+            if (request.TryGetValue("userID", out tmpObj))
+                UUID.TryParse(tmpObj.ToString(), out principalID);
+            if (principalID.IsZero())
+            {
+                m_log.WarnFormat("[HGFRIENDS HANDLER]: no userID in gettravelingfriends request");
+                return FailureResult();
+            }
+
+            // auth capability: proves the caller genuinely holds principalID's own
+            // live session on this grid (checked against Presence in the service),
+            // since this endpoint is reachable from the public internet
+            UUID sessionID = UUID.Zero;
+            if (request.TryGetValue("sessionID", out tmpObj))
+                UUID.TryParse(tmpObj.ToString(), out sessionID);
+            if (sessionID.IsZero())
+            {
+                m_log.WarnFormat("[HGFRIENDS HANDLER]: no sessionID in gettravelingfriends request");
+                return FailureResult();
+            }
+
+            List<string> friends = new List<string>();
+            int i = 0;
+            foreach (KeyValuePair<string, object> kvp in request)
+            {
+                if (kvp.Key.Equals("friend_" + i.ToString()))
+                {
+                    friends.Add(kvp.Value.ToString());
+                    i++;
+                }
+            }
+
+            List<UUID> traveling = m_TheService.GetTravelingFriends(principalID, sessionID, friends);
+
+            Dictionary<string, object> result = new Dictionary<string, object>();
+            if (traveling == null || traveling.Count == 0)
+                result["RESULT"] = "NULL";
+            else
+            {
+                i = 0;
+                foreach (UUID f in traveling)
+                {
+                    result["friend_" + i] = f.ToString();
+                    i++;
+                }
+            }
+
+            string xmlString = ServerUtils.BuildXmlResponse(result);
+            return Util.UTF8NoBomEncoding.GetBytes(xmlString);
+        }
+
+        byte[] StatusNotifyTraveling(Dictionary<string, object> request)
+        {
+            object tmpObj;
+            UUID principalID = UUID.Zero;
+            if (request.TryGetValue("userID", out tmpObj))
+                UUID.TryParse(tmpObj.ToString(), out principalID);
+            if (principalID.IsZero())
+            {
+                m_log.WarnFormat("[HGFRIENDS HANDLER]: no userID in statusnotify_traveling request");
+                return FailureResult();
+            }
+
+            // auth capability: proves the caller genuinely holds principalID's own
+            // live session on this grid (checked against Presence in the service),
+            // since this endpoint is reachable from the public internet
+            UUID sessionID = UUID.Zero;
+            if (request.TryGetValue("sessionID", out tmpObj))
+                UUID.TryParse(tmpObj.ToString(), out sessionID);
+            if (sessionID.IsZero())
+            {
+                m_log.WarnFormat("[HGFRIENDS HANDLER]: no sessionID in statusnotify_traveling request");
+                return FailureResult();
+            }
+
+            bool online = true;
+            if (request.TryGetValue("online", out tmpObj))
+                bool.TryParse(tmpObj.ToString(), out online);
+
+            List<string> friends = new List<string>();
+            int i = 0;
+            foreach (KeyValuePair<string, object> kvp in request)
+            {
+                if (kvp.Key.Equals("friend_" + i.ToString()))
+                {
+                    friends.Add(kvp.Value.ToString());
+                    i++;
+                }
+            }
+
+            m_TheService.StatusNotifyTravelingFriends(principalID, sessionID, friends, online);
+
+            return SuccessResult();
         }
 
         byte[] StatusNotification(Dictionary<string, object> request)

--- a/OpenSim/Server/Handlers/Hypergrid/HomeAgentHandlers.cs
+++ b/OpenSim/Server/Handlers/Hypergrid/HomeAgentHandlers.cs
@@ -129,7 +129,6 @@ namespace OpenSim.Server.Handlers.Hypergrid
         public string host;
         public int port;
         public string gatekeeperServerURI;
-        public string destinationServerURI;
 
     }
 

--- a/OpenSim/Server/Handlers/Hypergrid/HypergridHandlers.cs
+++ b/OpenSim/Server/Handlers/Hypergrid/HypergridHandlers.cs
@@ -131,5 +131,39 @@ namespace OpenSim.Server.Handlers.Hypergrid
 
         }
 
+        /// <summary>
+        /// A visitor's home grid asks this grid to deliver a friend status
+        /// notification to that visitor, wherever they currently are on this grid.
+        /// The session ID acts as the auth capability; see GatekeeperService.StatusNotify.
+        /// </summary>
+        public XmlRpcResponse StatusNotify(XmlRpcRequest request, IPEndPoint remoteClient)
+        {
+            Hashtable requestData = (Hashtable)request.Params[0];
+
+            UUID sessionID = UUID.Zero;
+            UUID userID = UUID.Zero;
+            UUID friendID = UUID.Zero;
+            bool online = false;
+            if (requestData.ContainsKey("session_id"))
+                UUID.TryParse((string)requestData["session_id"], out sessionID);
+            if (requestData.ContainsKey("user_id"))
+                UUID.TryParse((string)requestData["user_id"], out userID);
+            if (requestData.ContainsKey("friend_id"))
+                UUID.TryParse((string)requestData["friend_id"], out friendID);
+            if (requestData.ContainsKey("online"))
+                Boolean.TryParse((string)requestData["online"], out online);
+
+            bool delivered = false;
+            if (!sessionID.IsZero() && !userID.IsZero() && !friendID.IsZero())
+                delivered = m_GatekeeperService.StatusNotify(sessionID, userID, friendID, online);
+
+            Hashtable hash = new Hashtable();
+            hash["result"] = delivered ? "true" : "false";
+
+            XmlRpcResponse response = new XmlRpcResponse();
+            response.Value = hash;
+            return response;
+        }
+
     }
 }

--- a/OpenSim/Server/Handlers/Simulation/AgentHandlers.cs
+++ b/OpenSim/Server/Handlers/Simulation/AgentHandlers.cs
@@ -115,6 +115,8 @@ namespace OpenSim.Server.Handlers.Simulation
             destination.RegionLocX = data.x;
             destination.RegionLocY = data.y;
             destination.RegionName = data.name;
+            if (!string.IsNullOrEmpty(data.destinationServerURI))
+                destination.ServerURI = data.destinationServerURI;
 
             GridRegion gatekeeper = ExtractGatekeeper(data);
 
@@ -687,5 +689,6 @@ namespace OpenSim.Server.Handlers.Simulation
         public UUID uuid;
         public uint flags;
         public bool fromLogin;
+        public string destinationServerURI; // sim ServerURI; sent on HG logins ("destination_serveruri")
     }
 }

--- a/OpenSim/Services/Connectors/Hypergrid/GatekeeperServiceConnector.cs
+++ b/OpenSim/Services/Connectors/Hypergrid/GatekeeperServiceConnector.cs
@@ -340,5 +340,78 @@ namespace OpenSim.Services.Connectors.Hypergrid
 
             return null;
         }
+
+        /// <summary>
+        /// Ask a foreign grid's gatekeeper to deliver a friend status notification to
+        /// one of our users traveling there. The remote grid resolves the traveler's
+        /// current sim from its own presence data and forwards grid-internally, so
+        /// the notification arrives even after intra-grid teleports we never see.
+        /// </summary>
+        /// <param name="gatekeeperURI">The foreign grid's gatekeeper URI</param>
+        /// <param name="sessionID">The traveler's session ID as stored in HGTravelingData</param>
+        /// <param name="userID">The traveler's User ID (the recipient)</param>
+        /// <param name="friendID">The friend whose status changed</param>
+        /// <param name="online">true = came online, false = went offline</param>
+        /// <param name="notSupported">[out] true if the remote grid answered but doesn't
+        /// implement status_notify (older OpenSim); the caller should stop asking it</param>
+        /// <returns>true if the remote grid found the traveler and forwarded the
+        /// notification; false if the traveler isn't there or the call failed</returns>
+        public bool StatusNotify(string gatekeeperURI, UUID sessionID, UUID userID, UUID friendID, bool online, out bool notSupported)
+        {
+            notSupported = false;
+
+            Hashtable hash = new Hashtable();
+            hash["session_id"] = sessionID.ToString();
+            hash["user_id"] = userID.ToString();
+            hash["friend_id"] = friendID.ToString();
+            hash["online"] = online.ToString();
+
+            IList paramList = new ArrayList();
+            paramList.Add(hash);
+
+            XmlRpcRequest request = new XmlRpcRequest("status_notify", paramList);
+            XmlRpcResponse response = null;
+            try
+            {
+                using HttpClient hclient = WebUtil.GetNewGlobalHttpClient(10000);
+                response = request.Send(gatekeeperURI, hclient);
+            }
+            catch (Exception e)
+            {
+                // transport failure: the grid may just be unreachable right now
+                m_log.DebugFormat("[GATEKEEPER SERVICE CONNECTOR]: StatusNotify exception contacting {0}: {1}", gatekeeperURI, e.Message);
+                return false;
+            }
+
+            if (response.IsFault)
+            {
+                // Only an explicit unknown-method fault marks the grid as not
+                // supporting status_notify (older OpenSim). Other faults (e.g. a
+                // handler exception on the remote) are transient and must not
+                // get the grid cached as unsupported.
+                if (response.FaultCode == XmlRpcErrorCodes.SERVER_ERROR_METHOD)
+                {
+                    m_log.DebugFormat("[GATEKEEPER SERVICE CONNECTOR]: status_notify not supported by {0}: {1}", gatekeeperURI, response.FaultString);
+                    notSupported = true;
+                }
+                else
+                    m_log.DebugFormat("[GATEKEEPER SERVICE CONNECTOR]: status_notify fault from {0}: {1} ({2})", gatekeeperURI, response.FaultString, response.FaultCode);
+                return false;
+            }
+
+            try
+            {
+                hash = (Hashtable)response.Value;
+                bool delivered = false;
+                Boolean.TryParse((string)hash["result"], out delivered);
+                return delivered;
+            }
+            catch (Exception e)
+            {
+                m_log.DebugFormat("[GATEKEEPER SERVICE CONNECTOR]: Got exception while parsing status_notify response: {0}", e.Message);
+            }
+
+            return false;
+        }
     }
 }

--- a/OpenSim/Services/Connectors/Hypergrid/HGFriendsServicesConnector.cs
+++ b/OpenSim/Services/Connectors/Hypergrid/HGFriendsServicesConnector.cs
@@ -256,6 +256,109 @@ namespace OpenSim.Services.Connectors.Hypergrid
 
         }
 
+        /// <summary>
+        /// Tell the (own) grid's HGFriendsService that a local user's status changed,
+        /// so it can deliver to local friends traveling on foreign grids. Fire-and-forget:
+        /// the reply carries no data. Older services log an unknown-method warning and
+        /// return failure, which is silently ignored — pre-fix behavior.
+        /// </summary>
+        /// <param name="sessionID">userID's own live session on this grid — the auth
+        /// capability for this call, since /hgfriends is a publicly reachable endpoint
+        /// (other grids call statusnotification on the same port); only userID's own
+        /// connected sim knows this value, so it proves the call is genuine and not a
+        /// spoofed/probing request from an arbitrary caller who merely knows two UUIDs.</param>
+        public void StatusNotifyTraveling(List<string> friends, UUID userID, UUID sessionID, bool online)
+        {
+            Dictionary<string, object> sendData = new Dictionary<string, object>();
+
+            sendData["METHOD"] = "statusnotify_traveling";
+            sendData["userID"] = userID.ToString();
+            sendData["sessionID"] = sessionID.ToString();
+            sendData["online"] = online.ToString();
+            int i = 0;
+            foreach (string s in friends)
+            {
+                sendData["friend_" + i.ToString()] = s;
+                i++;
+            }
+
+            string uri = m_ServerURI + "/hgfriends";
+            try
+            {
+                SynchronousRestFormsRequester.MakeRequest("POST",
+                        uri,
+                        ServerUtils.BuildQueryString(sendData),
+                        15,
+                        null,
+                        false);
+            }
+            catch (Exception e)
+            {
+                m_log.DebugFormat("[HGFRIENDS CONNECTOR]: Exception when contacting friends server at {0}: {1}", uri, e.Message);
+            }
+        }
+
+        /// <summary>
+        /// Ask the (own) grid's HGFriendsService which of the given local friends are
+        /// currently traveling on a foreign grid, for the login-time online snapshot.
+        /// Older services log an unknown-method warning and return failure, which
+        /// parses to an empty list — pre-fix behavior.
+        /// </summary>
+        /// <param name="sessionID">userID's own live session on this grid — see the
+        /// same auth-capability note on StatusNotifyTraveling.</param>
+        public List<UUID> GetTravelingFriends(UUID userID, UUID sessionID, List<string> friends)
+        {
+            Dictionary<string, object> sendData = new Dictionary<string, object>();
+            List<UUID> traveling = new List<UUID>();
+
+            sendData["METHOD"] = "gettravelingfriends";
+            sendData["userID"] = userID.ToString();
+            sendData["sessionID"] = sessionID.ToString();
+            int i = 0;
+            foreach (string s in friends)
+            {
+                sendData["friend_" + i.ToString()] = s;
+                i++;
+            }
+
+            string reply = string.Empty;
+            string uri = m_ServerURI + "/hgfriends";
+            try
+            {
+                // Short timeout: this call sits on the login path (GetOnlineFriends),
+                // unlike the fire-and-forget StatusNotifyTraveling above, so a wedged
+                // own-grid Robust must not stall every login by up to the connector's
+                // usual 15s ceiling.
+                reply = SynchronousRestFormsRequester.MakeRequest("POST",
+                        uri,
+                        ServerUtils.BuildQueryString(sendData),
+                        3,
+                        null,
+                        false);
+            }
+            catch (Exception e)
+            {
+                m_log.DebugFormat("[HGFRIENDS CONNECTOR]: Exception when contacting friends server at {0}: {1}", uri, e.Message);
+                return traveling;
+            }
+
+            if (reply != string.Empty)
+            {
+                Dictionary<string, object> replyData = ServerUtils.ParseXmlResponse(reply);
+
+                foreach (string key in replyData.Keys)
+                {
+                    if (key.StartsWith("friend_") && replyData[key] != null)
+                    {
+                        if (UUID.TryParse(replyData[key].ToString(), out UUID uuid))
+                            traveling.Add(uuid);
+                    }
+                }
+            }
+
+            return traveling;
+        }
+
         public List<UUID> StatusNotification(List<string> friends, UUID userID, bool online)
         {
             Dictionary<string, object> sendData = new Dictionary<string, object>();

--- a/OpenSim/Services/Connectors/Hypergrid/UserAgentServiceConnector.cs
+++ b/OpenSim/Services/Connectors/Hypergrid/UserAgentServiceConnector.cs
@@ -50,7 +50,17 @@ namespace OpenSim.Services.Connectors.Hypergrid
         private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
 
         private string m_ServerURL;
-        private GridRegion m_Gatekeeper;
+        // PackData needs the gatekeeper and the real target region, but only
+        // receives the synthetic home region built in LoginAgentToGrid.
+        // They ride on that per-call object rather than on instance fields:
+        // this connector is cached and shared (LLLoginService,
+        // HGEntityTransferModule), so instance fields would race between
+        // concurrent logins.
+        private sealed class LoginContextRegion : GridRegion
+        {
+            public GridRegion Gatekeeper;
+            public GridRegion Destination;
+        }
 
         public UserAgentServiceConnector(string url)
         {
@@ -115,15 +125,15 @@ namespace OpenSim.Services.Connectors.Hypergrid
                 return false;
             }
 
-            GridRegion home = new GridRegion()
+            GridRegion home = new LoginContextRegion()
             {
                 ServerURI = m_ServerURL,
                 RegionID = destination.RegionID,
                 RegionLocX = destination.RegionLocX,
-                RegionLocY = destination.RegionLocY
+                RegionLocY = destination.RegionLocY,
+                Gatekeeper = gatekeeper,
+                Destination = destination
             };
-
-            m_Gatekeeper = gatekeeper;
 
             //Console.WriteLine("   >>> LoginAgentToGrid <<< " + home.ServerURI);
 
@@ -141,10 +151,27 @@ namespace OpenSim.Services.Connectors.Hypergrid
         protected override void PackData(OSDMap args, GridRegion source, AgentCircuitData aCircuit, GridRegion destination, uint flags)
         {
             base.PackData(args, source, aCircuit, destination, flags);
-            args["gatekeeper_serveruri"] = OSD.FromString(m_Gatekeeper.ServerURI);
-            args["gatekeeper_host"] = OSD.FromString(m_Gatekeeper.ExternalHostName);
-            args["gatekeeper_port"] = OSD.FromString(m_Gatekeeper.HttpPort.ToString());
-            args["destination_serveruri"] = OSD.FromString(destination.ServerURI);
+            if (destination is LoginContextRegion ctx)
+            {
+                args["gatekeeper_serveruri"] = OSD.FromString(ctx.Gatekeeper.ServerURI);
+                args["gatekeeper_host"] = OSD.FromString(ctx.Gatekeeper.ExternalHostName);
+                args["gatekeeper_port"] = OSD.FromString(ctx.Gatekeeper.HttpPort.ToString());
+                // the "destination" param here is the synthetic home region built
+                // in LoginAgentToGrid (its ServerURI is this connector's own URL);
+                // send the real target region's URI so the user agent service can
+                // record where the traveler actually lands.
+                args["destination_serveruri"] = OSD.FromString(ctx.Destination.ServerURI);
+            }
+            else
+            {
+                // CreateAgent on this connector is only ever expected to be reached
+                // via LoginAgentToGrid, which always builds a LoginContextRegion.
+                // Warn rather than silently sending a foreignagent post with no
+                // gatekeeper/destination info, which the receiving HG handler needs.
+                m_log.WarnFormat("[USER AGENT CONNECTOR]: PackData called with a plain destination ({0}); " +
+                    "gatekeeper and destination_serveruri fields will be missing from this request",
+                    destination?.RegionName ?? "null");
+            }
         }
 
         public void SetClientToken(UUID sessionID, string token)
@@ -515,6 +542,14 @@ namespace OpenSim.Services.Connectors.Hypergrid
                 url = hash["URL"].ToString();
 
             return url;
+        }
+
+        // Remote user agent services do not expose an endpoint for this; delivery
+        // to travelers is only possible when HGFriendsService and UserAgentService
+        // share the same Robust process (local implementation).
+        public bool StatusNotifyTravelingAgent(UUID userID, UUID friendID, bool online)
+        {
+            return false;
         }
 
         public string GetUUI(UUID userID, UUID targetUserID)

--- a/OpenSim/Services/Connectors/Presence/PresenceServicesConnector.cs
+++ b/OpenSim/Services/Connectors/Presence/PresenceServicesConnector.cs
@@ -367,6 +367,13 @@ namespace OpenSim.Services.Connectors
             return rinfos.ToArray();
         }
 
+        // Not wired to a remote call: only Robust-local callers (e.g.
+        // HGFriendsService, which loads PresenceService in-process) need this
+        // post-logout auth capability today.
+        public bool WasRecentlyLoggedOut(UUID sessionID, UUID userID)
+        {
+            return false;
+        }
 
         #endregion
 

--- a/OpenSim/Services/HypergridService/GatekeeperService.cs
+++ b/OpenSim/Services/HypergridService/GatekeeperService.cs
@@ -35,6 +35,7 @@ using OpenSim.Framework;
 using OpenSim.Services.Interfaces;
 using GridRegion = OpenSim.Services.Interfaces.GridRegion;
 using OpenSim.Server.Base;
+using OpenSim.Services.Connectors.Friends;
 using OpenSim.Services.Connectors.InstantMessage;
 using OpenSim.Services.Connectors.Hypergrid;
 using OpenMetaverse;
@@ -52,6 +53,7 @@ namespace OpenSim.Services.HypergridService
 
         private static IGridService m_GridService;
         private static IPresenceService m_PresenceService;
+        private static readonly FriendsSimConnector m_FriendsSimConnector = new();
         private static IUserAccountService m_UserAccountService;
         private static IUserAgentService m_UserAgentService;
         private static ISimulationService m_SimulationService;
@@ -312,6 +314,40 @@ namespace OpenSim.Services.HypergridService
                 agentHomeURI is null ? "" : " @ " + agentHomeURI);
 
             return region;
+        }
+
+        public bool StatusNotify(UUID sessionID, UUID userID, UUID friendID, bool online)
+        {
+            // The session ID is the auth capability here: only the visitor's viewer and
+            // their home grid (via HGTravelingData) know it, so this can't be used by
+            // third parties to probe user locations or spoof status events. The
+            // friendship was validated by the home grid before it called us.
+            PresenceInfo presence = m_PresenceService.GetAgent(sessionID);
+            if (presence is null || presence.RegionID.IsZero() || presence.UserID != userID.ToString())
+            {
+                // visible refusal rather than a silent false: a null presence is normal
+                // (visitor not arrived yet or already gone — the home grid falls back to
+                // the stored sim URI), but a user mismatch means a bad or spoofed capability
+                m_log.DebugFormat("[GATEKEEPER SERVICE]: StatusNotify for visitor {0} not deliverable: {1}",
+                    userID,
+                    presence is null ? "no presence for the presented session"
+                        : presence.RegionID.IsZero() ? "presence has no region"
+                        : "session belongs to another user");
+                return false;
+            }
+
+            GridRegion region = m_GridService.GetRegionByUUID(m_ScopeID, presence.RegionID);
+            if (region is null)
+            {
+                m_log.DebugFormat("[GATEKEEPER SERVICE]: StatusNotify for visitor {0} not deliverable: region {1} not found",
+                    userID, presence.RegionID);
+                return false;
+            }
+
+            m_log.DebugFormat("[GATEKEEPER SERVICE]: StatusNotify: visitor {0} is at {1}; forwarding status of {2}",
+                userID, region.RegionName, friendID);
+
+            return m_FriendsSimConnector.StatusNotify(region, friendID, userID.ToString(), online);
         }
 
         #region Login Agent

--- a/OpenSim/Services/HypergridService/HGFriendsService.cs
+++ b/OpenSim/Services/HypergridService/HGFriendsService.cs
@@ -61,6 +61,7 @@ namespace OpenSim.Services.HypergridService
         protected static IFriendsService m_FriendsService;
         protected static IPresenceService m_PresenceService;
         protected static IUserAccountService m_UserAccountService;
+        protected static IUserAgentService m_UserAgentService; // optional; enables notifications for traveling friends
         protected static IFriendsSimConnector m_FriendsLocalSimConnector; // standalone, points to HGFriendsModule
         protected static FriendsSimConnector m_FriendsSimConnector; // grid
 
@@ -105,6 +106,17 @@ namespace OpenSim.Services.HypergridService
                 m_PresenceService = ServerUtils.LoadPlugin<IPresenceService>(theService, args);
 
                 m_FriendsSimConnector = new FriendsSimConnector();
+
+                // Enables status notifications for friends traveling on foreign grids.
+                // This is the same UserAgentService key HGFriendServerConnector already
+                // requires in [HGFriendsService], so it is present on standard HG setups.
+                theService = serverConfig.GetString("UserAgentService", string.Empty);
+                if (theService.Length > 0)
+                {
+                    m_UserAgentService = ServerUtils.LoadPlugin<IUserAgentService>(theService, args);
+                    if (m_UserAgentService == null)
+                        m_log.WarnFormat("[HGFRIENDS SERVICE]: Could not load UserAgentService '{0}'. Traveling friend notifications disabled.", theService);
+                }
 
                 m_log.DebugFormat("[HGFRIENDS SERVICE]: Starting...");
 
@@ -290,13 +302,89 @@ namespace OpenSim.Services.HypergridService
 //                //m_log.WarnFormat("[HGFRIENDS SERVICE]: User {0} is visiting another grid. HG Status notifications still not implemented.", user);
 //            }
 
+            // Notify local friends who are currently traveling on foreign grids.
+            // Friendship was already confirmed above via the per-friend secret,
+            // so no extra verification is needed here.
+            if (m_UserAgentService != null && usersToBeNotified.Count > 0)
+            {
+                localFriendsOnline.AddRange(
+                    TravelingFriendsNotifier.DeliverStatusToTravelers(
+                        m_UserAgentService, usersToBeNotified, foreignUserID, online));
+            }
+
             // and finally, let's send the online friends
             if (online)
-            {
                 return localFriendsOnline;
-            }
-            else
+
+            return new List<UUID>();
+        }
+
+        public void StatusNotifyTravelingFriends(UUID userID, UUID sessionID, List<string> friends, bool online)
+        {
+            if (m_FriendsService == null || m_UserAgentService == null)
+                return;
+
+            // auth capability: without this, anyone who knows two account UUIDs could
+            // call this public endpoint directly to confirm a friendship + traveling
+            // status, or inject spoofed online/offline events
+            if (!IsOwnLiveSession(userID, sessionID, "statusnotify_traveling"))
+                return;
+
+            // public, unauthenticated-by-session-key endpoint: confirm the claimed
+            // friendship before delivering anything
+            TravelingFriendsNotifier.DeliverStatusToTravelers(
+                m_UserAgentService, friends, userID, online,
+                id => TravelingFriendsNotifier.IsLocalFriend(m_FriendsService, id, userID));
+        }
+
+        public List<UUID> GetTravelingFriends(UUID userID, UUID sessionID, List<string> friends)
+        {
+            if (m_FriendsService == null || m_UserAgentService == null)
                 return new List<UUID>();
+
+            if (!IsOwnLiveSession(userID, sessionID, "gettravelingfriends"))
+                return new List<UUID>();
+
+            return TravelingFriendsNotifier.FilterTraveling(
+                m_UserAgentService, friends,
+                id => TravelingFriendsNotifier.IsLocalFriend(m_FriendsService, id, userID));
+        }
+
+        /// <summary>
+        /// Confirms sessionID is a currently live Presence session belonging to userID
+        /// on this grid — the auth capability for the two wire methods above. Only
+        /// userID's own connected sim (or their viewer) can know this value, so it
+        /// proves the caller is genuine rather than an arbitrary third party who only
+        /// knows the account UUIDs involved.
+        /// </summary>
+        private static bool IsOwnLiveSession(UUID userID, UUID sessionID, string caller)
+        {
+            if (sessionID.IsZero())
+            {
+                m_log.DebugFormat("[HGFRIENDS SERVICE]: {0} for user {1} rejected: no session ID presented",
+                    caller, userID);
+                return false;
+            }
+
+            PresenceInfo p = m_PresenceService.GetAgent(sessionID);
+            if (p != null && p.UserID == userID.ToString())
+                return true;
+
+            // Offline notifications are sent right after logout, and
+            // PresenceService.LogoutAgent already deletes the session
+            // synchronously on the sim's connection-close path — well before
+            // this async request can arrive. Fall back to the short post-logout
+            // grace window so genuine "I just went offline" calls still pass.
+            if (m_PresenceService.WasRecentlyLoggedOut(sessionID, userID))
+                return true;
+
+            // rejections must be visible: a silent drop here looks identical to
+            // "friend is offline" and is very hard to diagnose from the outside
+            m_log.DebugFormat("[HGFRIENDS SERVICE]: {0} for user {1} rejected: session {2} is {3}",
+                caller, userID, sessionID,
+                p == null ? "not a live session nor a recent logout (split presence service, expired grace window, or a spoofed request)"
+                          : "live but belongs to another user");
+            return false;
         }
 
         #endregion IHGFriendsService

--- a/OpenSim/Services/HypergridService/TravelingFriendsNotifier.cs
+++ b/OpenSim/Services/HypergridService/TravelingFriendsNotifier.cs
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) Contributors, http://opensimulator.org/
+ * See CONTRIBUTORS.TXT for a full list of copyright holders.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the OpenSimulator Project nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE DEVELOPERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+using OpenSim.Framework;
+using OpenSim.Services.Interfaces;
+using FriendInfo = OpenSim.Services.Interfaces.FriendInfo;
+
+using OpenMetaverse;
+using log4net;
+
+namespace OpenSim.Services.HypergridService
+{
+    /// <summary>
+    /// Given local friend-ID candidates that have no live local presence,
+    /// determines which are traveling on a foreign grid (one cheap indexed
+    /// LocateUser read per candidate, so the common "simply offline" case
+    /// never touches the Friends store) and either delivers their status or
+    /// reports which are traveling. Shared by HGFriendsService.StatusNotification
+    /// (local branch), HGFriendsService.StatusNotifyTravelingFriends/
+    /// GetTravelingFriends (the statusnotify_traveling / gettravelingfriends
+    /// wire methods), and UserAgentService.NotifyFriendsOfStatus.
+    /// HG-only plumbing: lives entirely in this Robust HG service project;
+    /// the sim-side base FriendsModule never references it.
+    /// </summary>
+    internal static class TravelingFriendsNotifier
+    {
+        private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+
+        /// <summary>Delivers a friend's status change to whichever of the given
+        /// candidates turn out to be traveling on a foreign grid.</summary>
+        /// <returns>Delivered friend UUIDs. Only meaningful when online is
+        /// true (matches the existing StatusNotification/StatusNotifyTravelingFriends
+        /// wire-response convention: an offline reply is always empty).</returns>
+        internal static List<UUID> DeliverStatusToTravelers(
+            IUserAgentService userAgentService,
+            IEnumerable<string> candidateFriendIDs,
+            UUID counterpartID,
+            bool online,
+            Func<UUID, bool> verifyFriend = null)
+        {
+            List<UUID> delivered = new();
+            if (userAgentService is null)
+                return delivered;
+
+            foreach (string candidate in candidateFriendIDs)
+            {
+                if (!UUID.TryParse(candidate, out UUID id))
+                    continue;
+
+                // cheap DB-only check so the common "friend is just offline"
+                // case never touches the Friends store; delivery itself is
+                // done off-thread below
+                if (string.IsNullOrEmpty(userAgentService.LocateUser(id)))
+                    continue;
+
+                if (verifyFriend != null && !verifyFriend(id))
+                    continue;
+
+                m_log.DebugFormat("[TRAVELING FRIENDS NOTIFIER]: {0} is traveling; forwarding status of {1}",
+                    id, counterpartID);
+
+                Util.FireAndForget(o =>
+                {
+                    userAgentService.StatusNotifyTravelingAgent(id, counterpartID, online);
+                }, null, "TravelingFriendsNotifier.DeliverStatusToTraveler");
+
+                if (online)
+                    delivered.Add(id);
+            }
+
+            return delivered;
+        }
+
+        /// <summary>Read-only counterpart for the login-time online snapshot
+        /// (GetTravelingFriends): same gate, no delivery.</summary>
+        internal static List<UUID> FilterTraveling(
+            IUserAgentService userAgentService,
+            IEnumerable<string> candidateFriendIDs,
+            Func<UUID, bool> verifyFriend = null)
+        {
+            List<UUID> traveling = new();
+            if (userAgentService is null)
+                return traveling;
+
+            foreach (string candidate in candidateFriendIDs)
+            {
+                if (!UUID.TryParse(candidate, out UUID id))
+                    continue;
+                if (string.IsNullOrEmpty(userAgentService.LocateUser(id)))
+                    continue;
+                if (verifyFriend != null && !verifyFriend(id))
+                    continue;
+                traveling.Add(id);
+            }
+
+            return traveling;
+        }
+
+        /// <summary>Exact local (plain-UUID) friendship match, plus the same
+        /// CanSeeOnline right the sim itself already filters by before ever
+        /// reaching this grid — checked again here as defense in depth, since
+        /// this is called from wire-facing methods that authenticate the caller
+        /// but not, on their own, whether that friendship still grants
+        /// visibility. Foreign friend rows carry secrets and are validated by
+        /// StatusNotification instead.</summary>
+        internal static bool IsLocalFriend(IFriendsService friendsService, UUID candidateID, UUID counterpartID)
+        {
+            FriendInfo[] finfos = friendsService?.GetFriends(candidateID);
+            if (finfos is null)
+                return false;
+
+            string counterpartStr = counterpartID.ToString();
+            foreach (FriendInfo finfo in finfos)
+                if (finfo.Friend == counterpartStr)
+                    // TheirFlags here is counterpartID's grant to candidateID
+                    // (this row belongs to candidateID, "Their" = the other side)
+                    return finfo.TheirFlags != -1 && (finfo.TheirFlags & (int)FriendRights.CanSeeOnline) != 0;
+
+            return false;
+        }
+    }
+}

--- a/OpenSim/Services/HypergridService/UserAgentService.cs
+++ b/OpenSim/Services/HypergridService/UserAgentService.cs
@@ -82,6 +82,11 @@ namespace OpenSim.Services.HypergridService
         private static readonly Dictionary<int, List<string>> m_TripsAllowedExceptions = new();
         private static readonly Dictionary<int, List<string>> m_TripsDisallowedExceptions = new();
 
+        // grids known to not implement status_notify (older OpenSim), so we don't
+        // keep sending them a request that will fail; re-probed after expiry
+        private const int STATUS_NOTIFY_UNSUPPORTED_MS = 3600 * 1000;
+        private static readonly ExpiringCacheOS<string, bool> m_StatusNotifyUnsupported = new(60000);
+
         public UserAgentService(IConfigSource config) : this(config, null)
         {
         }
@@ -279,7 +284,7 @@ namespace OpenSim.Services.HypergridService
 
             // Generate a new service session
             agentCircuit.ServiceSessionID = region.ServerURI + ";" + UUID.Random();
-            TravelingAgentInfo travel = CreateTravelInfo(agentCircuit, region, fromLogin, out TravelingAgentInfo old);
+            TravelingAgentInfo travel = CreateTravelInfo(agentCircuit, region, fromLogin, finalDestination.ServerURI, out TravelingAgentInfo old);
 
             if(!fromLogin && old is not null && !string.IsNullOrEmpty(old.ClientIPAddress))
             {
@@ -327,7 +332,7 @@ namespace OpenSim.Services.HypergridService
             return LoginAgentToGrid(source, agentCircuit, gatekeeper, finalDestination, false, out reason);
         }
 
-        TravelingAgentInfo CreateTravelInfo(AgentCircuitData agentCircuit, GridRegion region, bool fromLogin, out TravelingAgentInfo existing)
+        TravelingAgentInfo CreateTravelInfo(AgentCircuitData agentCircuit, GridRegion region, bool fromLogin, string regionServerURI, out TravelingAgentInfo existing)
         {
             HGTravelingData hgt = m_Database.Get(agentCircuit.SessionID);
             existing = null;
@@ -346,7 +351,8 @@ namespace OpenSim.Services.HypergridService
                 SessionID = agentCircuit.SessionID,
                 UserID = agentCircuit.AgentID,
                 GridExternalName = region.ServerURI,
-                ServiceToken = agentCircuit.ServiceSessionID
+                ServiceToken = agentCircuit.ServiceSessionID,
+                RegionServerURI = regionServerURI
             };
 
             if (fromLogin)
@@ -361,11 +367,114 @@ namespace OpenSim.Services.HypergridService
         {
             m_log.DebugFormat("[USER AGENT SERVICE]: User {0} logged out", userID);
 
+            // Capture whether this session was a stay on a foreign grid before
+            // deleting it. This method is also called for ordinary local
+            // logouts (the local sim notifies friends itself in that case).
+            // m_GridName is lowercased in the constructor while GridExternalName
+            // is stored raw, so the comparison must ignore case
+            HGTravelingData hgt = m_Database.Get(sessionID);
+            bool wasTravelingAbroad = hgt is not null && hgt.Data is not null
+                && hgt.Data.TryGetValue("GridExternalName", out string gridName)
+                && !m_GridName.Equals(gridName, StringComparison.InvariantCultureIgnoreCase);
+
             m_Database.Delete(sessionID);
 
             GridUserInfo guinfo = m_GridUserService.GetGridUserInfo(userID.ToString());
             if (guinfo is not null)
                 m_GridUserService.LoggedOut(userID.ToString(), sessionID, guinfo.LastRegionID, guinfo.LastPosition, guinfo.LastLookAt);
+
+            // A user logging out on a foreign grid has no sim on this grid to
+            // send the offline status to their friends, and the foreign sim
+            // doesn't know the visitor's friends; notify them from here.
+            if (wasTravelingAbroad)
+                Util.FireAndForget(o => NotifyFriendsOfStatus(userID, false), null, "UserAgentService.NotifyFriendsLoggedOut");
+        }
+
+        /// <summary>
+        /// Send a status notification to all friends of this (local) user.
+        /// Used when the status change happens on a foreign grid, where no sim
+        /// of this grid is involved that could notify them.
+        /// </summary>
+        protected void NotifyFriendsOfStatus(UUID userID, bool online)
+        {
+            if (m_FriendsService is null)
+                return;
+
+            FriendInfo[] friends = m_FriendsService.GetFriends(userID);
+            if (friends is null || friends.Length == 0)
+                return;
+
+            List<string> localFriends = new();
+            Dictionary<string, List<string>> foreignFriendsPerDomain = new();
+            foreach (FriendInfo fi in friends)
+            {
+                // same filter the sim-side FriendsModule.StatusChange applies
+                if (fi.TheirFlags == -1 || (fi.MyFlags & (int)FriendRights.CanSeeOnline) == 0)
+                    continue;
+
+                if (UUID.TryParse(fi.Friend, out _))
+                    localFriends.Add(fi.Friend);
+                else if (Util.ParseUniversalUserIdentifier(fi.Friend, out _, out string url, out _, out _, out _))
+                {
+                    // foreign friend: group per grid, notified below
+                    if (!foreignFriendsPerDomain.TryGetValue(url, out List<string> lst))
+                    {
+                        lst = new List<string>();
+                        foreignFriendsPerDomain[url] = lst;
+                    }
+                    lst.Add(fi.Friend);
+                }
+            }
+
+            if (localFriends.Count > 0)
+            {
+                // one batched presence lookup for all local friends instead of
+                // one query per friend
+                Dictionary<string, PresenceInfo> homeSessions = new();
+                PresenceInfo[] sessions = m_PresenceService?.GetAgents(localFriends.ToArray());
+                if (sessions is not null)
+                    foreach (PresenceInfo p in sessions)
+                        if (!p.RegionID.IsZero() && !homeSessions.ContainsKey(p.UserID)) // guard against traveling agents
+                            homeSessions[p.UserID] = p;
+
+                List<string> notAtHome = new(localFriends.Count);
+                foreach (string friend in localFriends)
+                {
+                    // local friend: if online at home, notify their sim...
+                    if (homeSessions.TryGetValue(friend, out PresenceInfo session))
+                    {
+                        NotifyLocalSimOfStatus(session.RegionID, userID, friend, online);
+                        continue;
+                    }
+
+                    // ...or, if they are traveling abroad themselves, deliver via the
+                    // visited grid below.
+                    notAtHome.Add(friend);
+                }
+
+                // This is our own authoritative friend list for userID, already
+                // filtered to local (plain-UUID) friends above, so no verifyFriend
+                // callback is needed. The helper fires off one worker per candidate
+                // internally, so one unreachable grid's request timeout can't stall
+                // the notifications to the others.
+                if (notAtHome.Count > 0)
+                    TravelingFriendsNotifier.DeliverStatusToTravelers(this, notAtHome, userID, online);
+            }
+
+            foreach (KeyValuePair<string, List<string>> kvp in foreignFriendsPerDomain)
+            {
+                m_log.DebugFormat("[USER AGENT SERVICE]: Notifying {0} friends in {1} that user {2} is {3}",
+                    kvp.Value.Count, kvp.Key, userID, online ? "online" : "offline");
+                // each domain gets its own worker so one unreachable grid's
+                // request timeout can't stall notifications to the others
+                string domain = kvp.Key;
+                List<string> ids = kvp.Value;
+                Util.FireAndForget(o =>
+                {
+                    HGFriendsServicesConnector fConn = new HGFriendsServicesConnector(domain);
+                    fConn.StatusNotification(ids, userID, online);
+                }, null, "UserAgentService.NotifyForeignFriendsOfStatus");
+            }
         }
 
         // We need to prevent foreign users with the same UUID as a local user
@@ -499,6 +608,14 @@ namespace OpenSim.Services.HypergridService
         [Obsolete]
         protected void ForwardStatusNotificationToSim(UUID regionID, UUID foreignUserID, string user, bool online)
         {
+            NotifyLocalSimOfStatus(regionID, foreignUserID, user, online);
+        }
+
+        // Same local-sim-vs-remote-REST dispatch as the obsolete method above
+        // (and HGFriendsService's copy of it), kept non-obsolete so new code
+        // (NotifyFriendsOfStatus) doesn't have to call deprecated API.
+        private void NotifyLocalSimOfStatus(UUID regionID, UUID foreignUserID, string user, bool online)
+        {
             if (UUID.TryParse(user, out UUID userID))
             {
                 if (m_FriendsLocalSimConnector is not null)
@@ -625,10 +742,67 @@ namespace OpenSim.Services.HypergridService
                 return string.Empty;
 
             foreach (HGTravelingData t in hgts)
-                if (t.Data.ContainsKey("GridExternalName") && !m_GridName.Equals(t.Data["GridExternalName"]))
-                    return t.Data["GridExternalName"];
+                // case-insensitive: m_GridName is lowercased, GridExternalName is stored raw
+                if (t.Data.TryGetValue("GridExternalName", out string gridName)
+                    && !m_GridName.Equals(gridName, StringComparison.InvariantCultureIgnoreCase))
+                    return gridName;
 
             return string.Empty;
+        }
+
+        public bool StatusNotifyTravelingAgent(UUID userID, UUID friendID, bool online)
+        {
+            HGTravelingData[] hgts = m_Database.GetSessions(userID);
+            if (hgts == null)
+                return false;
+
+            foreach (HGTravelingData t in hgts)
+            {
+                // case-insensitive: m_GridName is lowercased, GridExternalName is stored raw
+                if (!t.Data.TryGetValue("GridExternalName", out string gridName)
+                    || m_GridName.Equals(gridName, StringComparison.InvariantCultureIgnoreCase))
+                    continue;
+
+                // Preferred: hand the notification to the visited grid's gatekeeper,
+                // which resolves the traveler's current sim from its own presence
+                // data and forwards grid-internally. This reaches the traveler even
+                // after intra-grid teleports we never see. Note this does network
+                // I/O; call from a worker thread.
+                if (!m_StatusNotifyUnsupported.ContainsKey(gridName))
+                {
+                    bool delivered = m_GatekeeperConnector.StatusNotify(gridName, t.SessionID, userID, friendID, online, out bool notSupported);
+                    if (delivered)
+                    {
+                        m_log.DebugFormat("[USER AGENT SERVICE]: {0} is traveling in {1}; status of {2} delivered via its gatekeeper",
+                            userID, gridName, friendID);
+                        return true;
+                    }
+                    if (notSupported)
+                    {
+                        // older grid without status_notify: stop asking it for a while
+                        m_StatusNotifyUnsupported.Add(gridName, true, STATUS_NOTIFY_UNSUPPORTED_MS);
+                    }
+                    // else: the grid is unreachable, or it couldn't deliver (which is
+                    // also the case in the short window after arrival before the
+                    // destination sim reports the agent to presence); fall through to
+                    // the stored sim URI as best effort
+                }
+
+                // Fallback: send directly to the sim recorded when the user entered
+                // the grid. Only written at grid crossings, so it goes stale after
+                // intra-grid teleports there — the pre-status_notify behavior.
+                if (t.Data.TryGetValue("RegionURI", out string storedURI) && !string.IsNullOrEmpty(storedURI))
+                {
+                    m_log.DebugFormat("[USER AGENT SERVICE]: {0} is traveling in {1}; forwarding status of {2} to sim {3}",
+                        userID, gridName, friendID, storedURI);
+                    GridRegion region = new GridRegion { ServerURI = storedURI };
+                    m_FriendsSimConnector.StatusNotify(region, friendID, userID.ToString(), online);
+                    return true;
+                }
+                // no usable route in this record; a newer session row may have one
+            }
+
+            return false;
         }
 
         public string GetUUI(UUID userID, UUID targetUserID)
@@ -708,7 +882,8 @@ namespace OpenSim.Services.HypergridService
                 {
                     ["GridExternalName"] = travel.GridExternalName,
                     ["ServiceToken"] = travel.ServiceToken,
-                    ["ClientIPAddress"] = travel.ClientIPAddress
+                    ["ClientIPAddress"] = travel.ClientIPAddress,
+                    ["RegionURI"] = travel.RegionServerURI
                 }
             };
 
@@ -725,6 +900,7 @@ namespace OpenSim.Services.HypergridService
         public string GridExternalName = string.Empty;
         public string ServiceToken = string.Empty;
         public string ClientIPAddress = string.Empty; // as seen from this user agent service
+        public string RegionServerURI = string.Empty; // ServerURI of the specific sim region the user landed in
 
         public TravelingAgentInfo(HGTravelingData t)
         {
@@ -735,6 +911,8 @@ namespace OpenSim.Services.HypergridService
                 GridExternalName = t.Data["GridExternalName"];
                 ServiceToken = t.Data["ServiceToken"];
                 ClientIPAddress = t.Data["ClientIPAddress"];
+                if (t.Data.ContainsKey("RegionURI"))
+                    RegionServerURI = t.Data["RegionURI"];
             }
         }
 
@@ -747,6 +925,7 @@ namespace OpenSim.Services.HypergridService
                 GridExternalName = old.GridExternalName;
                 ServiceToken = old.ServiceToken;
                 ClientIPAddress = old.ClientIPAddress;
+                RegionServerURI = old.RegionServerURI;
             }
         }
     }

--- a/OpenSim/Services/Interfaces/IHypergridServices.cs
+++ b/OpenSim/Services/Interfaces/IHypergridServices.cs
@@ -54,6 +54,22 @@ namespace OpenSim.Services.Interfaces
 
         bool LoginAgent(GridRegion source, AgentCircuitData aCircuit, GridRegion destination, out string reason);
 
+        /// <summary>
+        /// Delivers a friend status notification to a Hypergrid visitor currently on
+        /// this grid: resolves the visitor's current sim from this grid's presence
+        /// data and forwards the event grid-internally, so it reaches the visitor
+        /// even after intra-grid teleports the home grid never sees. The caller must
+        /// present the visitor's session ID, which only the visitor's viewer and
+        /// their home grid know, so third parties can't probe user locations or
+        /// spoof status events. The friendship itself is validated by the caller
+        /// (the visitor's home grid); this grid only checks the session capability.
+        /// </summary>
+        /// <param name="sessionID">The visitor's session ID, as stored by the home grid at HG login</param>
+        /// <param name="userID">The visitor's User ID; must match the session</param>
+        /// <param name="friendID">The friend whose status changed</param>
+        /// <param name="online">true = came online, false = went offline</param>
+        /// <returns>true if the visitor was found and the notification was forwarded to their sim</returns>
+        bool StatusNotify(UUID sessionID, UUID userID, UUID friendID, bool online);
     }
 
     public interface IUserAgentService
@@ -86,9 +102,22 @@ namespace OpenSim.Services.Interfaces
         /// <summary>
         /// Returns the current location of a remote user.
         /// </summary>
-        /// <returns>On success: the user's Server URLs. If the user doesn't exist: "".</returns>
+        /// <returns>On success: the external grid URL where the user is traveling. If the user doesn't exist or is at home: "".</returns>
         /// <remarks>Throws an exception if an error occurs (e.g., can't contact the server).</remarks>
         string LocateUser(UUID userID);
+
+        /// <summary>
+        /// Sends a friend status notification to a local user who is traveling on a
+        /// foreign grid. Prefers handing delivery to the visited grid's gatekeeper
+        /// (status_notify), which resolves the traveler's current sim from its own
+        /// presence data; falls back to the sim URI recorded at grid entry when the
+        /// visited grid is an older OpenSim. Does network I/O; call from a worker thread.
+        /// </summary>
+        /// <param name="userID">The traveling local user (the recipient)</param>
+        /// <param name="friendID">The friend whose status changed</param>
+        /// <param name="online">true = came online, false = went offline</param>
+        /// <returns>true if a delivery attempt was made</returns>
+        bool StatusNotifyTravelingAgent(UUID userID, UUID friendID, bool online);
 
         /// <summary>
         /// Returns the Universal User Identifier for 'targetUserID' on behalf of 'userID'.
@@ -134,6 +163,45 @@ namespace OpenSim.Services.Interfaces
         bool ValidateFriendshipOffered(UUID fromID, UUID toID);
         // Returns the local friends online
         List<UUID> StatusNotification(List<string> friends, UUID userID, bool online);
+
+        /// <summary>
+        /// A local user's status changed at home; deliver it to those of their local
+        /// friends who are traveling on a foreign grid. Called by this grid's own sims
+        /// with the friends that had no home presence (travelers and offline friends
+        /// look identical there — the home presence row is deleted while abroad).
+        /// Friends without a travel record (simply offline) are filtered out by one
+        /// cheap indexed read; only exact local (plain UUID) friendships are delivered,
+        /// foreign friends flow through StatusNotification with their secrets instead.
+        /// This method (like GetTravelingFriends) is reachable on the same publicly
+        /// exposed port as StatusNotification, so sessionID acts as the auth
+        /// capability in place of a per-friendship secret — see its own doc.
+        /// </summary>
+        /// <param name="userID">The local user whose status changed</param>
+        /// <param name="sessionID">userID's own live session on this grid, as held by
+        /// their connected sim. Verified against Presence before anything is delivered:
+        /// only userID's own sim (or their viewer) can know this value, so it proves
+        /// the request is genuine rather than an arbitrary caller who merely knows two
+        /// account UUIDs — this endpoint is otherwise unauthenticated.</param>
+        /// <param name="friends">Candidate local friend IDs with no home presence</param>
+        /// <param name="online">true = came online, false = went offline</param>
+        void StatusNotifyTravelingFriends(UUID userID, UUID sessionID, List<string> friends, bool online);
+
+        /// <summary>
+        /// Returns which of the given candidates are local friends of userID currently
+        /// traveling on a foreign grid. Used by the sims to include travelers in the
+        /// login-time online-friends snapshot (they have no home presence row while
+        /// abroad, so presence alone reports them offline). Candidates without a
+        /// travel record are filtered by one cheap indexed read; only exact local
+        /// (plain UUID) friendships are reported.
+        /// </summary>
+        /// <param name="userID">The local user logging in</param>
+        /// <param name="sessionID">userID's own live session on this grid — same auth
+        /// capability role as on StatusNotifyTravelingFriends; this is a public,
+        /// otherwise-unauthenticated endpoint and must not answer for an arbitrary
+        /// caller who only knows userID.</param>
+        /// <param name="friends">Candidate local friend IDs with no home presence</param>
+        /// <returns>The subset of candidates that are friends and traveling</returns>
+        List<UUID> GetTravelingFriends(UUID userID, UUID sessionID, List<string> friends);
     }
 
     public interface IInstantMessageSimConnector

--- a/OpenSim/Services/Interfaces/IPresenceService.cs
+++ b/OpenSim/Services/Interfaces/IPresenceService.cs
@@ -105,5 +105,14 @@ namespace OpenSim.Services.Interfaces
         /// <returns>Session information for the users.</returns>
         /// <param name='userIDs'></param>
         PresenceInfo[] GetAgents(string[] userIDs);
+
+        /// <summary>
+        /// Whether sessionID was a live session belonging to userID until just
+        /// recently (a short grace window after LogoutAgent deleted it). Lets
+        /// callers authenticate "this user just logged out" requests, whose
+        /// session is by definition already gone from GetAgent by the time an
+        /// async caller can check it.
+        /// </summary>
+        bool WasRecentlyLoggedOut(UUID sessionID, UUID userID);
     }
 }

--- a/OpenSim/Services/PresenceService/PresenceService.cs
+++ b/OpenSim/Services/PresenceService/PresenceService.cs
@@ -48,6 +48,11 @@ namespace OpenSim.Services.PresenceService
         static ExpiringCacheOS<UUID, PresenceData> BySessionCache = new ExpiringCacheOS<UUID, PresenceData>(60000);
         static ExpiringCacheOS<string, PresenceData> ByUserCache = new ExpiringCacheOS<string, PresenceData>(60000);
 
+        // short post-logout grace window so a session that just closed can still
+        // authenticate its own "I went offline" notifications (see WasRecentlyLoggedOut)
+        const int RECENT_LOGOUT_GRACE_MS = 60000;
+        static ExpiringCacheOS<UUID, string> RecentlyLoggedOut = new ExpiringCacheOS<UUID, string>(RECENT_LOGOUT_GRACE_MS);
+
         public PresenceService(IConfigSource config)
             : base(config)
         {
@@ -112,6 +117,9 @@ namespace OpenSim.Services.PresenceService
                 sessionID,
                 (presence == null) ? null : presence.UserID,
                 (presence == null) ? null : presence.RegionID.ToString());
+
+            if (presence is not null)
+                RecentlyLoggedOut.Add(sessionID, presence.UserID, RECENT_LOGOUT_GRACE_MS);
 
             bool ret = m_Database.Delete("SessionID", sessionID.ToString());
             if(inCache)
@@ -202,6 +210,11 @@ namespace OpenSim.Services.PresenceService
                 RegionID = data.RegionID
             };
             return ret;
+        }
+
+        public bool WasRecentlyLoggedOut(UUID sessionID, UUID userID)
+        {
+            return RecentlyLoggedOut.TryGetValue(sessionID, out string uid) && uid == userID.ToString();
         }
 
         public PresenceInfo[] GetAgents(string[] userIDs)


### PR DESCRIPTION
- Added StatusNotifyTraveling and GetTravelingFriends methods to HGFriendsServicesConnector for notifying local friends about their status while traveling on foreign grids.
- Enhanced UserAgentService to handle status notifications for users traveling abroad, including the ability to notify friends when a user logs out on a foreign grid.
- Introduced TravelingFriendsNotifier to manage the delivery of status updates to friends who are traveling.
- Updated GatekeeperService to forward status notifications to the appropriate friends' services.
- Modified PresenceService to track recent logouts, allowing for accurate status notifications shortly after a user logs out.
- Updated IHypergridServices and IPresenceService interfaces to include new methods for handling traveling friends and logout notifications.