### PR TITLE
Add MapTilesDirectory setting to configure map tile location

### DIFF
--- a/OpenSim/Region/CoreModules/World/Warp3DMap/Warp3DImageModule.cs
+++ b/OpenSim/Region/CoreModules/World/Warp3DMap/Warp3DImageModule.cs
@@ -84,6 +84,8 @@ namespace OpenSim.Region.CoreModules.World.Warp3DMap
         private float m_renderMinHeight = -100f;
         private float m_renderMaxHeight = 4096f;
 
+        private string m_mapTilesDirectory = string.Empty; // directory to load/save map tile images
+
         private bool m_Enabled = false;
 
         #region Region Module interface
@@ -132,6 +134,9 @@ namespace OpenSim.Region.CoreModules.World.Warp3DMap
                 m_renderMinHeight = -100f;
             else if (m_renderMinHeight > m_renderMaxHeight - 10f)
                 m_renderMinHeight = m_renderMaxHeight - 10f;
+
+            m_mapTilesDirectory =
+                Util.GetConfigVarFromSections<string>(source, "MapTilesDirectory", configSections, m_mapTilesDirectory);
         }
 
         public void AddRegion(Scene scene)
@@ -209,6 +214,11 @@ namespace OpenSim.Region.CoreModules.World.Warp3DMap
             Bitmap tile = GenImage();
             // image may be reloaded elsewhere, so no compression format
             string filename = "MAP-" + m_scene.RegionInfo.RegionID.ToString() + ".png";
+            if (!string.IsNullOrEmpty(m_mapTilesDirectory))
+            {
+                Directory.CreateDirectory(m_mapTilesDirectory);
+                filename = System.IO.Path.Combine(m_mapTilesDirectory, filename);
+            }
             tile.Save(filename,ImageFormat.Png);
             m_primMesher = null;
             return tile;

--- a/OpenSim/Region/CoreModules/World/WorldMap/WorldMapModule.cs
+++ b/OpenSim/Region/CoreModules/World/WorldMap/WorldMapModule.cs
@@ -100,6 +100,7 @@ namespace OpenSim.Region.CoreModules.World.WorldMap
         protected bool m_exportPrintScale = false; // prints the scale of map in meters on exported map
         protected bool m_exportPrintRegionName = false; // prints the region name exported map
         protected bool m_localV1MapAssets = false; // keep V1 map assets only on  local cache
+        protected string m_mapTilesDirectory = string.Empty; // directory to load/save map tile images
 
         private readonly object m_sceneLock = new object();
         public WorldMapModule()
@@ -158,6 +159,8 @@ namespace OpenSim.Region.CoreModules.World.WorldMap
                 Util.GetConfigVarFromSections<bool>(config, "ExportMapAddRegionName", configSections, m_exportPrintRegionName);
             m_localV1MapAssets =
                 Util.GetConfigVarFromSections<bool>(config, "LocalV1MapAssets", configSections, m_localV1MapAssets);
+            m_mapTilesDirectory =
+                Util.GetConfigVarFromSections<string>(config, "MapTilesDirectory", configSections, m_mapTilesDirectory);
         }
 
         public virtual void AddRegion(Scene scene)
@@ -1339,6 +1342,8 @@ namespace OpenSim.Region.CoreModules.World.WorldMap
 
             bool doneLocal = false;
             string filename = "MAP-" + m_scene.RegionInfo.RegionID.ToString() + ".png";
+            if (!string.IsNullOrEmpty(m_mapTilesDirectory))
+                filename = Path.Combine(m_mapTilesDirectory, filename);
             try
             {
                 using(Image localMap = Bitmap.FromFile(filename))

--- a/bin/OpenSimDefaults.ini
+++ b/bin/OpenSimDefaults.ini
@@ -467,6 +467,11 @@
     ; generate better images.
     ;MapImageModule = "MapImageModule"
 
+    ; Directory used to load and save the generated MAP-<region uuid>.png tile images.
+    ; If left empty the current working directory is used (default behaviour).
+    ; The directory is created automatically if it does not exist.
+    ;MapTilesDirectory = "./maptiles"
+
     ; World map blacklist timeout in seconds
     ;BlacklistTimeout = 600
 


### PR DESCRIPTION
## Introduction

I setup OpenSim in a way nothing is written in the `bin` directory, so paths
of various modules are set by config to write elsewhere. If `Warp3DImageModule`
is used, OpenSim crashes at startup if I set `bin` directory read-only.
There is no setting to set a different path for generated textures.

This PR adds a new `MapTilesDirectory` option to the `[Map]` config section that
controls where the `MAP-<region uuid>.png` tile images are saved and loaded
from. Previously these files were always written to and read from the current
working directory.

## Changes
- `Warp3DImageModule` saves the generated tile into the configured directory,
  creating it if it does not exist.
- `WorldMapModule` loads the local tile from the configured directory when
  exporting the world map (`export-map`).
- Documented the new option in `bin/OpenSimDefaults.ini`.

## Compatibility
When `MapTilesDirectory` is left empty (the default), the current working
directory is used, preserving the previous behaviour. No migration required.

## Notes
The default `MapImageModule` writes its tile directly to the asset service
rather than to an on-disk `MAP-*.png` file, so it is unaffected by this
setting — only the Warp3D writer and the WorldMap exporter touch that file.