### PR TITLE
Mark scripts as HasRun on every run (fix empty state on teleport)

### DIFF
--- a/OpenSim/Region/ScriptEngine/YEngine/XMRInstRun.cs
+++ b/OpenSim/Region/ScriptEngine/YEngine/XMRInstRun.cs
@@ -318,6 +318,9 @@ namespace OpenSim.Region.ScriptEngine.Yengine
                     m_LastRanAt = now;
                     m_InstEHSlice++;
                     callMode = CallMode_NORMAL;
+                    // The script really executes here, so it has meaningful
+                    // state to serialize — GetXMLState gates on this flag.
+                    m_HasRun = true;
                     e = ResumeEx();
                 }
 
@@ -393,6 +396,8 @@ namespace OpenSim.Region.ScriptEngine.Yengine
                     m_DetectParams = evt.DetectParams;
                     m_LastRanAt = now;
                     m_InstEHEvent++;
+                    // Starting a new event handler counts as "has run".
+                    m_HasRun = true;
                     e = StartEventHandler(evc, evt.Params);
                 }
 


### PR DESCRIPTION
Sometimes m_HasRun is false, even when the script is running.
Hence script state is not serialized on sim log out(TP) and destination sim received empty script state.
m_HasRun can be enforced true on running the script.
This is needed to advance in keeping scripts running in HG Teleports.