### PR TITLE
Add MinPoolThreads setting to OpenSimDefaults.ini

### DIFF
--- a/bin/OpenSimDefaults.ini
+++ b/bin/OpenSimDefaults.ini
@@ -61,6 +61,10 @@
     ; QueueUserWorkItem, SmartThreadPool, and Thread.
     async_call_method = SmartThreadPool
 
+    ; Min threads to allocate on the FireAndForget thread pool
+    ; when running with the SmartThreadPool option above
+    MinPoolThreads = 2
+
     ; Max threads to allocate on the FireAndForget thread pool
     ; when running with the SmartThreadPool option above
     MaxPoolThreads = 300


### PR DESCRIPTION
MinPoolThreads setting missing from OpenSimDefaults.ini making it difficult to discover for Grid/Sim admins.
DotNet delays the creation of new threads, some admins may want to keep a minimum of ready threads, like 16 or 32.
The default `stpMinThreads` is 2 in the code.