### PR TITLE
Gate HGUuidGatherer per-asset Debug logs on WebUtil.DebugLevel

### DIFF
--- a/OpenSim/Region/Framework/Scenes/UuidGatherer.cs
+++ b/OpenSim/Region/Framework/Scenes/UuidGatherer.cs
@@ -1337,10 +1337,15 @@ namespace OpenSim.Region.Framework.Scenes
         {
             string IDstr = assetID.ToString();
             AssetBase asset = m_assetService.Get(IDstr, m_assetServerURL, true);
-            if (asset is null)
-                m_log.Debug($"[HGUUIDGatherer]: Failed to fetch asset {IDstr} from {m_assetServerURL}");
-            else
-                m_log.Debug($"[HGUUIDGatherer]: Copied asset {IDstr} from {m_assetServerURL} to local asset server");
+            // Per-asset Debug is expensive (sync File+Console). Only when HTTP debug is on:
+            //   debug http all|out N   (WebUtil.DebugLevel > 0)
+            if (WebUtil.DebugLevel > 0)
+            {
+                if (asset is null)
+                    m_log.Debug($"[HGUUIDGatherer]: Failed to fetch asset {IDstr} from {m_assetServerURL}");
+                else
+                    m_log.Debug($"[HGUUIDGatherer]: Copied asset {IDstr} from {m_assetServerURL} to local asset server");
+            }
 
             return asset;
         }


### PR DESCRIPTION
Per-asset m_log.Debug lines dominate HG attachment gather time. Emit them only when HTTP debug is enabled (debug http all|out N), keep HG logins (HG Asset Gathering) fast.