### PR TITLE
Resume attachment scripts after HG Teleport

### DIFF
--- a/OpenSim/Region/CoreModules/Framework/EntityTransfer/EntityTransferModule.cs
+++ b/OpenSim/Region/CoreModules/Framework/EntityTransfer/EntityTransferModule.cs
@@ -2851,6 +2851,21 @@ namespace OpenSim.Region.CoreModules.Framework.EntityTransfer
             }
 
             sp.GotAttachmentsData = true;
+
+            // On HG login, and cross-grid HG teleport (HG entry), `CompleteMovement` has run already with an empty asset list.
+            // HG login attaches after async asset gather.
+            
+            // If the agent is root now, start scripts here (same as CompleteMovement for local teleports).
+            // If still a child (sim-crossing or local TP) then CompleteMovement will start the scripts.
+            if (!sp.IsChildAgent && !m_scene.RegionInfo.RegionSettings.DisableScripts)
+            {
+                int stateSource = sp.GetStateSource();
+                foreach (SceneObjectGroup sog in sp.GetAttachments())
+                {
+                    sog.CreateScriptInstances(0, false, m_scene.DefaultScriptEngine, stateSource);
+                    sog.ResumeScripts();
+                }
+            }
             return true;
         }
 

--- a/OpenSim/Region/Framework/Scenes/ScenePresence.cs
+++ b/OpenSim/Region/Framework/Scenes/ScenePresence.cs
@@ -2374,8 +2374,19 @@ namespace OpenSim.Region.Framework.Scenes
                     {
                         foreach (SceneObjectGroup sog in m_attachments)
                         {
-                            sog.RootPart.ParentGroup.CreateScriptInstances(0, false, m_scene.DefaultScriptEngine, GetStateSource());
-                            sog.ResumeScripts();
+                            // HG gather starts scripts after assets arrive (fast or slow).
+                            // Starting them here as well double-inits timer/listen/sensor scripts.
+                            // On HGLogin script may or may not have been downloaded yet, may or may not be in cache.
+                            
+                            bool localUser = m_scene.UserManagementModule.IsLocalGridUser(UUID);
+                            bool hgEntry = (m_teleportFlags & TeleportFlags.ViaHGLogin) != 0;
+
+                            // Only foreign HG visitors wait on gather. Local homecoming does not.
+                            if (!hgEntry || localUser)
+                            {
+                                sog.RootPart.ParentGroup.CreateScriptInstances(0, false, m_scene.DefaultScriptEngine, GetStateSource());
+                                sog.ResumeScripts();
+                            }
                         }
 
                         foreach (ScenePresence p in allpresences)


### PR DESCRIPTION
Local login starts scripts on CompleteMovement for local teleports.
HGLogin for local avatar starts scripts on CompleteMovement , local avatar TP back to Home Grid.
HGLogin for foreign avatar starts scripts in HandleIncomingAttachments after assets are gathered.