### PR TITLE
Sync max sim height with viewer limit

### DIFF
--- a/OpenSim/Framework/Constants.cs
+++ b/OpenSim/Framework/Constants.cs
@@ -57,7 +57,7 @@ namespace OpenSim.Framework
         public const int LandUnit = 4; // parcels only have sizes multiple of this
 
         public const float MinSimulationHeight = -100f;
-        public const float MaxSimulationHeight = 50000f;
+        public const float MaxSimulationHeight = 65536f;
         public const float MinTerrainHeightmap = -100f;
         public const float MaxTerrainHeightmap = 4000f;
         public const float MinWaterHeight = 0;


### PR DESCRIPTION
New viewer teleport limits set the maximum height to 65536 to make skyboxes above 4096 reachable more easily. Limit is already at 50k so this just syncs it up with the viewer.