### PR TITLE
HG Standalone Offline IM config

### DIFF
--- a/OpenSim/Services/HypergridService/HGInstantMessageService.cs
+++ b/OpenSim/Services/HypergridService/HGInstantMessageService.cs
@@ -136,6 +136,9 @@ namespace OpenSim.Services.HypergridService
                     string offlineIMService = cnf.GetString("OfflineIMService", string.Empty);
                     if (offlineIMService != string.Empty)
                         m_OfflineIMService = ServerUtils.LoadPlugin<IOfflineIMService>(offlineIMService, args);
+                    
+                    if (m_OfflineIMService is null)
+                        m_log.Warn("[HG IM SERVICE]: InGatekeeper is true but [Messaging] OfflineIMService is missing or failed to load; incoming IMs to offline users will not be stored");
                 }
                 else
                     m_log.Debug("[HG IM SERVICE]: Starting");

--- a/bin/OpenSim.ini.example
+++ b/bin/OpenSim.ini.example
@@ -821,6 +821,10 @@
     ;; Or, alternatively, use this one, which works for both standalones and grids
     ; OfflineMessageModule = "Offline Message Module V2"
 
+    ;; Required on Hypergrid standalone (InGatekeeper) so incoming IMs to
+    ;; offline local users are stored. Robust.HG.ini.example has the same key.
+    ; OfflineIMService = "OpenSim.Addons.OfflineIM.dll:OfflineIMService"
+
     ;# {OfflineMessageURL} {OfflineMessageModule:OfflineMessageModule Offline Message Module V2:Offline Message Module V2} {URL of offline messaging service} {}
     ;; URL of web service for offline message storage. Leave it commented if your service is local to the sim.
     ; OfflineMessageURL = ${Const|BaseURL}/Offline.php


### PR DESCRIPTION
Example configuration missing on OpenSim.ini.example for Offline IMs to work in HG Stand alone.