### PR TITLE
Update HGFriendsService.cs

### DIFF
--- a/OpenSim/Services/HypergridService/HGFriendsService.cs
+++ b/OpenSim/Services/HypergridService/HGFriendsService.cs
@@ -254,28 +254,37 @@ namespace OpenSim.Services.HypergridService
             //m_log.DebugFormat("[HGFRIENDS SERVICE]: Status notification: user has {0} local friends", usersToBeNotified.Count);
 
             // First, let's send notifications to local users who are online in the home grid
-            PresenceInfo[] friendSessions = m_PresenceService.GetAgents(usersToBeNotified.ToArray());
+
+            PresenceInfo[] friendSessions =
+                m_PresenceService.GetAgents(usersToBeNotified.ToArray());
+            
             if (friendSessions != null && friendSessions.Length > 0)
             {
-                PresenceInfo friendSession = null;
-                foreach (PresenceInfo pinfo in friendSessions)
-                    if (!pinfo.RegionID.IsZero()) // let's guard against traveling agents
-                    {
-                        friendSession = pinfo;
-                        break;
-                    }
-
-                if (friendSession != null)
+                foreach (PresenceInfo friendSession in friendSessions)
                 {
-                    ForwardStatusNotificationToSim(friendSession.RegionID, foreignUserID, friendSession.UserID, online);
-                    usersToBeNotified.Remove(friendSession.UserID.ToString());
-                    UUID id;
-                    if (UUID.TryParse(friendSession.UserID, out id))
+                    // Guard against agents currently traveling between regions.
+                    if (friendSession.RegionID.IsZero())
+                        continue;
+            
+                    ForwardStatusNotificationToSim(
+                        friendSession.RegionID,
+                        foreignUserID,
+                        friendSession.UserID,
+                        online
+                    );
+            
+                    usersToBeNotified.Remove(
+                        friendSession.UserID.ToString()
+                    );
+            
+                    if (UUID.TryParse(friendSession.UserID, out UUID id) &&
+                        !localFriendsOnline.Contains(id))
+                    {
                         localFriendsOnline.Add(id);
-
+                    }
                 }
             }
-
+            
 //            // Lastly, let's notify the rest who may be online somewhere else
 //            foreach (string user in usersToBeNotified)
 //            {


### PR DESCRIPTION
the 'break' on line 265 kicks it out of the loop after first friend, so only first friend appears online, other friends on same grid do not appear online.

can test with curl:

```

curl -sS -m 20 -X POST "http://hg....com:80/hgfriends" \
  --data-urlencode "METHOD=statusnotification" \
  --data-urlencode "userID=GUID" \
  --data-urlencode "online=True" \
  --data-urlencode "friend_0=FRIEND_GUID_WITH_GRID_AND_KEY" \
  --data-urlencode "friend_1=FRIEND_GUID_WITH_GRID_AND_KEY"
  
```

also maybe worth looking at is HGFriendsServerPostHandler.cs - the current code iterates the dictionary object.  it assumes that the post arguments are in a certain order and that the dictionary object keeps them in the same order. possibly dictionary won't do that. it might be better to iterate by int i instead. but that's your call maybe although it seems like trouble it's really worry over nothing.

update example:

```
int i = 0;
while (request.TryGetValue("friend_" + i, out object friendObj))
{
    if (friendObj != null)
        friends.Add(friendObj.ToString());

    i++;
}
```
